### PR TITLE
Replace Briefcase packaging with Windows private-runtime packager and NSIS installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ z.py
 todo
 .claude/
 .copilot-tracking/
-.briefcase/
 
 .pyemsi
 # Byte-compiled / optimized / DLL files

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,6 +36,8 @@ python setup.py build_ext --inplace
 
 The compiled extension will be written into `pyemsi/core/`.
 
+The Windows private-runtime packager also depends on this in-place extension artifact. Re-run this command before invoking [tools/build_windows_private_runtime.py](./tools/build_windows_private_runtime.py) if the compiled module is missing or stale.
+
 ## Related Guides
 
 - For user installation, see [INSTALLATION.md](./INSTALLATION.md).

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -3,7 +3,7 @@
 This repository produces two primary distributables:
 
 - The `pyemsi` API wheel (`.whl`) via the standard Python build flow.
-- The `pyemsi_gui` desktop installer via Briefcase.
+- A Windows portable `pyemsi` GUI runtime staged under `dist/`.
 
 ## Build The `pyemsi` Wheel
 
@@ -24,54 +24,41 @@ Optional reinstall check:
 python -m pip install --force-reinstall dist/*.whl
 ```
 
-## Build The `pyemsi_gui` Installer
+## Build The Windows Portable GUI Runtime
 
-The Briefcase configuration lives in `pyproject.toml` under `[tool.briefcase.app.pyemsi_gui]`.
+The portable Windows builder lives at [tools/build_windows_private_runtime.py](./tools/build_windows_private_runtime.py). It assembles an embeddable Python runtime under `dist/pyemsi-windows-portable/`, stages the local `pyemsi` and `pyemsi_gui` source trees into `app/`, installs GUI dependencies into `runtime/`, and generates launcher batch files.
 
-1. Install Briefcase in the Python 3.11 environment:
-
-   ```bash
-   .venv311\Scripts\python.exe -m pip install --upgrade briefcase
-   ```
-
-2. Create or refresh the Windows app bundle:
+1. Rebuild the compiled extension in place before packaging:
 
    ```bash
-   .venv311\Scripts\python.exe -m briefcase create windows app --no-input
+   .venv311\Scripts\python.exe setup.py build_ext --inplace
    ```
 
-   If the template already exists, run:
+2. Run the Windows private-runtime builder:
 
    ```bash
-   .venv311\Scripts\python.exe -m briefcase update windows app -r --no-input
+   .venv311\Scripts\python.exe .\tools\build_windows_private_runtime.py
    ```
 
-3. Build the app:
+Optional flags:
 
-   ```bash
-   .venv311\Scripts\python.exe -m briefcase build windows app --no-input
-   ```
-
-4. Package the MSI installer:
-
-   ```bash
-   .venv311\Scripts\python.exe -m briefcase package windows -p msi --no-input
-   ```
+```bash
+.venv311\Scripts\python.exe .\tools\build_windows_private_runtime.py --skip-dependency-install --skip-smoke-test
+```
 
 Output:
 
-- Built app files are created under `build/pyemsi_gui/windows/app/`.
-- The MSI installer is written to `dist/` once WiX installation completes.
+- The embeddable Python cache is stored under `build/windows-private-runtime/cache/`.
+- The portable app is written to `dist/pyemsi-windows-portable/`.
+- The main launcher is `dist/pyemsi-windows-portable/run_pyemsi.bat`.
+- The helper script launcher is `dist/pyemsi-windows-portable/run_script.bat`.
 
 ## Windows Packaging Notes
 
-- The first MSI packaging run may prompt for WiX toolset installation.
-- If `briefcase create` fails because the app already exists, use `briefcase update windows app -r --no-input` and continue.
-- You can run the app without packaging it:
-
-```bash
-.venv311\Scripts\python.exe -m briefcase run windows app
-```
+- This flow currently targets Windows only because it relies on the official embeddable CPython distribution.
+- The builder expects `pyemsi/core/femap_parser*.pyd` and `pyemsi/resources/resources.py` to already exist in the repo tree.
+- The portable build preserves a real `runtime/python.exe` so packaged subprocess flows that depend on `sys.executable` continue to work.
+- This produces a portable folder, not an installer. Installer and shell-integration work can be added later as a separate step.
 
 ## Related Guides
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -1,9 +1,10 @@
 # Packaging And Distribution
 
-This repository produces two primary distributables:
+This repository produces three distributables:
 
 - The `pyemsi` API wheel (`.whl`) via the standard Python build flow.
 - A Windows portable `pyemsi` GUI runtime staged under `dist/`.
+- A Windows NSIS installer built from the portable runtime.
 
 ## Build The `pyemsi` Wheel
 
@@ -60,7 +61,33 @@ Output:
 - The builder expects `pyemsi/core/femap_parser*.pyd` and `pyemsi/resources/resources.py` to already exist in the repo tree.
 - When MSVC is available (Developer Command Prompt or discoverable via `vswhere`), the builder compiles native `.exe` launchers from [tools/launcher.c](./tools/launcher.c). The GUI launcher links as a Windows subsystem app and uses `pythonw.exe` so no console window appears.
 - The portable build preserves a real `runtime/python.exe` so packaged subprocess flows that depend on `sys.executable` continue to work.
-- This produces a portable folder, not an installer. Installer and shell-integration work can be added later as a separate step.
+- This produces a portable folder. To create an installer from it, see the next section.
+
+## Build The Windows NSIS Installer
+
+The NSIS script lives at [installer/pyemsi.nsi](./installer/pyemsi.nsi). It packages the portable runtime into a user-level installer with a modern UI wizard, GPLv3 license page, desktop shortcut, Start Menu group, and an "Open with pyemsi" folder context menu.
+
+Prerequisites:
+
+- [NSIS 3.x](https://nsis.sourceforge.io/) installed and `makensis` on `PATH`.
+- A completed portable runtime build under `dist/pyemsi/` (see above).
+
+From the repository root:
+
+```bash
+makensis installer\pyemsi.nsi
+```
+
+Output:
+
+- `dist/pyemsi-<version>-setup.exe`
+
+The installer:
+
+- Installs to `%LOCALAPPDATA%\pyemsi` by default (no admin required).
+- Creates a desktop shortcut and a Start Menu group.
+- Registers an "Open with pyemsi" entry in the Windows Explorer folder context menu.
+- Writes an uninstaller and Add/Remove Programs entry under `HKCU`.
 
 ## Related Guides
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -26,7 +26,7 @@ python -m pip install --force-reinstall dist/*.whl
 
 ## Build The Windows Portable GUI Runtime
 
-The portable Windows builder lives at [tools/build_windows_private_runtime.py](./tools/build_windows_private_runtime.py). It assembles an embeddable Python runtime under `dist/pyemsi-windows-portable/`, stages the local `pyemsi` and `pyemsi_gui` source trees into `app/`, installs GUI dependencies into `runtime/`, and generates launcher batch files.
+The portable Windows builder lives at [tools/build_windows_private_runtime.py](./tools/build_windows_private_runtime.py). It assembles an embeddable Python runtime under `dist/pyemsi-windows-portable/`, stages the local `pyemsi` source tree into `app/`, installs GUI dependencies into `runtime/`, and generates native `.exe` launchers (or `.bat` fallbacks when MSVC is not available).
 
 1. Rebuild the compiled extension in place before packaging:
 
@@ -50,13 +50,15 @@ Output:
 
 - The embeddable Python cache is stored under `build/windows-private-runtime/cache/`.
 - The portable app is written to `dist/pyemsi-windows-portable/`.
-- The main launcher is `dist/pyemsi-windows-portable/run_pyemsi.bat`.
-- The helper script launcher is `dist/pyemsi-windows-portable/run_script.bat`.
+- The main launcher is `dist/pyemsi-windows-portable/run_pyemsi.exe` (uses `pythonw.exe`, no console window).
+- The helper script launcher is `dist/pyemsi-windows-portable/run_script.exe`.
+- If MSVC is not found, `.bat` launchers are generated instead.
 
 ## Windows Packaging Notes
 
 - This flow currently targets Windows only because it relies on the official embeddable CPython distribution.
 - The builder expects `pyemsi/core/femap_parser*.pyd` and `pyemsi/resources/resources.py` to already exist in the repo tree.
+- When MSVC is available (Developer Command Prompt or discoverable via `vswhere`), the builder compiles native `.exe` launchers from [tools/launcher.c](./tools/launcher.c). The GUI launcher links as a Windows subsystem app and uses `pythonw.exe` so no console window appears.
 - The portable build preserves a real `runtime/python.exe` so packaged subprocess flows that depend on `sys.executable` continue to work.
 - This produces a portable folder, not an installer. Installer and shell-integration work can be added later as a separate step.
 

--- a/installer/pyemsi.nsi
+++ b/installer/pyemsi.nsi
@@ -1,0 +1,149 @@
+; pyemsi NSIS Installer Script
+; Requires NSIS 3.x with MUI2
+;
+; Build:  makensis installer\pyemsi.nsi
+; Source: expects a pre-built portable runtime in dist\pyemsi\
+
+;---------------------------------------------------------------------------
+; General
+;---------------------------------------------------------------------------
+!define APP_NAME        "pyemsi"
+!define APP_VERSION     "0.1.3"
+!define APP_PUBLISHER   "SSIL"
+!define APP_URL         "https://github.com/EMSolution-SSIL/pyemsi"
+!define APP_EXE         "pyemsi.exe"
+!define UNINSTALL_KEY   "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
+
+Unicode true
+Name "${APP_NAME} ${APP_VERSION}"
+OutFile "..\dist\${APP_NAME}-${APP_VERSION}-setup.exe"
+InstallDir "$LOCALAPPDATA\${APP_NAME}"
+InstallDirRegKey HKCU "${UNINSTALL_KEY}" "InstallLocation"
+RequestExecutionLevel user
+SetCompressor /SOLID lzma
+
+;---------------------------------------------------------------------------
+; Modern UI 2
+;---------------------------------------------------------------------------
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+
+!define MUI_ICON   "..\pyemsi\resources\icons\Icon.ico"
+!define MUI_UNICON "..\pyemsi\resources\icons\Icon.ico"
+
+!define MUI_ABORTWARNING
+!define MUI_FINISHPAGE_RUN "$INSTDIR\${APP_EXE}"
+!define MUI_FINISHPAGE_RUN_TEXT "Launch ${APP_NAME}"
+!define MUI_FINISHPAGE_LINK "Open documentation"
+!define MUI_FINISHPAGE_LINK_LOCATION "https://emsolution-ssil.github.io/pyemsi/"
+
+; --- Installer pages ---
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "..\LICENSE"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+; --- Uninstaller pages ---
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+; --- Language ---
+!insertmacro MUI_LANGUAGE "English"
+
+;---------------------------------------------------------------------------
+; Version metadata (shown in file properties)
+;---------------------------------------------------------------------------
+VIProductVersion "${APP_VERSION}.0"
+VIAddVersionKey "ProductName"     "${APP_NAME}"
+VIAddVersionKey "ProductVersion"  "${APP_VERSION}"
+VIAddVersionKey "CompanyName"     "${APP_PUBLISHER}"
+VIAddVersionKey "FileDescription" "${APP_NAME} Installer"
+VIAddVersionKey "LegalCopyright"  "GPLv3+"
+VIAddVersionKey "FileVersion"     "${APP_VERSION}.0"
+
+;---------------------------------------------------------------------------
+; Installer Section
+;---------------------------------------------------------------------------
+Section "${APP_NAME} (required)" SecCore
+    SectionIn RO ; cannot be unchecked
+    SetOutPath "$INSTDIR"
+
+    ; Copy the entire portable runtime
+    File /r "..\dist\pyemsi\*.*"
+
+    ; Write uninstaller
+    WriteUninstaller "$INSTDIR\uninstall.exe"
+
+    ; --- Add/Remove Programs entry ---
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "DisplayName"      "${APP_NAME} ${APP_VERSION}"
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "DisplayVersion"    "${APP_VERSION}"
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "Publisher"         "${APP_PUBLISHER}"
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "URLInfoAbout"      "${APP_URL}"
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "InstallLocation"   "$INSTDIR"
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "UninstallString"   "$INSTDIR\uninstall.exe"
+    WriteRegStr   HKCU "${UNINSTALL_KEY}" "DisplayIcon"       "$INSTDIR\${APP_EXE},0"
+    WriteRegDWORD HKCU "${UNINSTALL_KEY}" "NoModify"          1
+    WriteRegDWORD HKCU "${UNINSTALL_KEY}" "NoRepair"          1
+
+    ; Estimate installed size (in KB) for Add/Remove Programs
+    ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+    IntFmt $0 "0x%08X" $0
+    WriteRegDWORD HKCU "${UNINSTALL_KEY}" "EstimatedSize" $0
+SectionEnd
+
+;---------------------------------------------------------------------------
+; Optional Components
+;---------------------------------------------------------------------------
+Section "Desktop Shortcut" SecDesktop
+    CreateShortCut "$DESKTOP\${APP_NAME}.lnk" \
+                   "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
+SectionEnd
+
+Section "Start Menu Shortcut" SecStartMenu
+    CreateDirectory "$SMPROGRAMS\${APP_NAME}"
+    CreateShortCut  "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk" \
+                    "$INSTDIR\${APP_EXE}" "" "$INSTDIR\${APP_EXE}" 0
+    CreateShortCut  "$SMPROGRAMS\${APP_NAME}\Uninstall.lnk" \
+                    "$INSTDIR\uninstall.exe" "" "$INSTDIR\uninstall.exe" 0
+SectionEnd
+
+Section 'Explorer "Open with pyemsi"' SecContextMenu
+    WriteRegStr HKCU "Software\Classes\Directory\shell\${APP_NAME}" "" "Open with ${APP_NAME}"
+    WriteRegStr HKCU "Software\Classes\Directory\shell\${APP_NAME}" "Icon" "$INSTDIR\${APP_EXE},0"
+    WriteRegStr HKCU "Software\Classes\Directory\shell\${APP_NAME}\command" "" '"$INSTDIR\${APP_EXE}" "%1"'
+
+    WriteRegStr HKCU "Software\Classes\Directory\Background\shell\${APP_NAME}" "" "Open with ${APP_NAME}"
+    WriteRegStr HKCU "Software\Classes\Directory\Background\shell\${APP_NAME}" "Icon" "$INSTDIR\${APP_EXE},0"
+    WriteRegStr HKCU "Software\Classes\Directory\Background\shell\${APP_NAME}\command" "" '"$INSTDIR\${APP_EXE}" "%V"'
+SectionEnd
+
+;---------------------------------------------------------------------------
+; Component Descriptions
+;---------------------------------------------------------------------------
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+    !insertmacro MUI_DESCRIPTION_TEXT ${SecCore}        "Install ${APP_NAME} application files (required)."
+    !insertmacro MUI_DESCRIPTION_TEXT ${SecDesktop}     "Create a shortcut on the Desktop."
+    !insertmacro MUI_DESCRIPTION_TEXT ${SecStartMenu}   "Create a Start Menu program group."
+    !insertmacro MUI_DESCRIPTION_TEXT ${SecContextMenu}  "Add 'Open with ${APP_NAME}' to the folder right-click menu."
+!insertmacro MUI_FUNCTION_DESCRIPTION_END
+
+;---------------------------------------------------------------------------
+; Uninstaller Section
+;---------------------------------------------------------------------------
+Section "Uninstall"
+    ; --- Remove context menu entries ---
+    DeleteRegKey HKCU "Software\Classes\Directory\shell\${APP_NAME}"
+    DeleteRegKey HKCU "Software\Classes\Directory\Background\shell\${APP_NAME}"
+
+    ; --- Remove Add/Remove Programs entry ---
+    DeleteRegKey HKCU "${UNINSTALL_KEY}"
+
+    ; --- Remove shortcuts ---
+    Delete "$DESKTOP\${APP_NAME}.lnk"
+    RMDir /r "$SMPROGRAMS\${APP_NAME}"
+
+    ; --- Remove installed files ---
+    RMDir /r "$INSTDIR"
+SectionEnd

--- a/pyemsi/gui/__init__.py
+++ b/pyemsi/gui/__init__.py
@@ -39,6 +39,7 @@ _app = None
 def launch(
     title: str = "pyemsi",
     size: tuple[int, int] | None = None,
+    workspace_path: str | None = None,
 ) -> None:
     """
     Create and show the pyemsi main window, then start the Qt event loop.
@@ -51,6 +52,8 @@ def launch(
         Window title.
     size : tuple of int
         Window size as (width, height).
+    workspace_path : str, optional
+        Folder to open as the initial workspace.
     """
     global _window, _app
 
@@ -64,6 +67,11 @@ def launch(
 
     _window = PyEmsiMainWindow()
     _window.setWindowTitle(title)
+
+    if workspace_path is not None:
+        import os
+
+        _window._set_workspace_path(os.path.abspath(workspace_path))
 
     import pyemsi.gui as gui_module
 

--- a/pyemsi/gui/__main__.py
+++ b/pyemsi/gui/__main__.py
@@ -1,5 +1,11 @@
-"""Allow running pyemsi.gui as a module: python -m pyemsi.gui"""
+"""Allow running pyemsi.gui as a module: python -m pyemsi.gui [workspace]"""
+
+import argparse
+
+parser = argparse.ArgumentParser(prog="pyemsi", description="pyemsi GUI")
+parser.add_argument("workspace", nargs="?", default=None, help="Folder to open as workspace")
+args = parser.parse_args()
 
 from pyemsi.gui import launch
 
-launch()
+launch(workspace_path=args.workspace)

--- a/pyemsi_gui/__init__.py
+++ b/pyemsi_gui/__init__.py
@@ -1,1 +1,0 @@
-"""Briefcase launcher package for the pyemsi GUI app."""

--- a/pyemsi_gui/__main__.py
+++ b/pyemsi_gui/__main__.py
@@ -1,7 +1,0 @@
-"""Briefcase app entry point for pyemsi GUI."""
-
-from pyemsi.gui import launch
-
-
-if __name__ == "__main__":
-    launch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ include-package-data = true
 zip-safe = false
 
 [tool.setuptools.packages.find]
-include = ["pyemsi*", "pyemsi_gui*"]
+include = ["pyemsi*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "pyemsi.__version__"}
@@ -88,35 +88,9 @@ version = {attr = "pyemsi.__version__"}
 [tool.ruff]
 line-length = 120
 
-[tool.briefcase]
-project_name = "pyemsi"
-bundle = "com.emsolution"
-version = "0.1.3"
-
-[tool.briefcase.app.pyemsi_gui]
-formal_name = "pyemsi"
-description = "EMSolution Visualization Toolkit"
-console_app = false
-icon = "pyemsi/resources/icons/Icon"
-installer_icon = "pyemsi/resources/icons/Icon"
-sources = [
-    "pyemsi",
-    "pyemsi_gui",
-]
-requires = [
-    "vtk>=9.0.0",
-    "numpy>=1.21.0",
-    "pyvista>=0.43.0",
-    "pyvistaqt>=0.11.0",
-    "PySide6>=6.5.0",
-    "matplotlib>=3.5.0",
-    "qtconsole>=5.4.0",
-    "ipykernel>=6.0.0",
-    "markdown>=3.4.0",
-    "python-lsp-server[websockets]",
-    "basedpyright>=1.31.4",
-    "pywinpty",
-]
+[tool.pyemsi.windows-private-runtime]
+app_module = "pyemsi.gui"
+extra_dependencies = ["pywinpty"]
 
 # cibuildwheel configuration
 [tool.cibuildwheel]

--- a/tests/test_build_windows_private_runtime.py
+++ b/tests/test_build_windows_private_runtime.py
@@ -21,54 +21,16 @@ def _load_builder_module():
 builder = _load_builder_module()
 
 
-def test_read_runtime_dependencies_merges_project_and_runtime_extras():
-    pyproject_data = {
-        "project": {"dependencies": ["numpy>=1.21.0", "PySide6>=6.5.0"]},
-        "tool": {
-            "pyemsi": {
-                "windows-private-runtime": {
-                    "extra_dependencies": ["PySide6>=6.5.0", "pywinpty", "PySide6>=6.5.0"],
-                }
-            }
-        },
-    }
+def test_unique_strings_deduplicates_and_preserves_order():
+    result = builder._unique_strings(["numpy>=1.21.0", "PySide6>=6.5.0", "PySide6>=6.5.0", "pywinpty"])
 
-    dependencies = builder.read_runtime_dependencies(pyproject_data)
-
-    assert dependencies == ("numpy>=1.21.0", "PySide6>=6.5.0", "pywinpty")
+    assert result == ("numpy>=1.21.0", "PySide6>=6.5.0", "pywinpty")
 
 
-def test_read_runtime_dependencies_keeps_project_only_packages():
-    pyproject_data = {
-        "project": {"dependencies": ["scienceplots", "numpy>=1.21.0"]},
-        "tool": {
-            "pyemsi": {
-                "windows-private-runtime": {
-                    "extra_dependencies": ["numpy>=1.21.0", "pywinpty"],
-                }
-            }
-        },
-    }
+def test_unique_strings_skips_non_strings_and_blanks():
+    result = builder._unique_strings(["numpy", 42, "", None, "  pyvista  "])
 
-    dependencies = builder.read_runtime_dependencies(pyproject_data)
-
-    assert dependencies == ("scienceplots", "numpy>=1.21.0", "pywinpty")
-
-
-def test_read_app_module_prefers_runtime_tool_config():
-    pyproject_data = {
-        "tool": {
-            "pyemsi": {
-                "windows-private-runtime": {
-                    "app_module": "pyemsi.gui",
-                }
-            }
-        }
-    }
-
-    app_module = builder.read_app_module(pyproject_data, default="fallback.module")
-
-    assert app_module == "pyemsi.gui"
+    assert result == ("numpy", "pyvista")
 
 
 def test_load_build_config_uses_runtime_tool_app_module(tmp_path):
@@ -112,11 +74,21 @@ def test_render_launcher_bat_targets_private_runtime_module():
     assert '"%BASE_DIR%runtime\\python.exe" -m pyemsi.gui %*' in launcher
 
 
+def test_render_launcher_bat_script_mode():
+    launcher = builder.render_launcher_bat(script_mode=True)
+
+    assert "set SCRIPT=%~1" in launcher
+    assert '"%BASE_DIR%runtime\\python.exe" "%SCRIPT%" %*' in launcher
+    assert "-m" not in launcher
+
+
 def test_build_layout_uses_scoped_output_directories(tmp_path):
     layout = builder.build_layout(tmp_path)
 
     assert layout.build_dir == tmp_path / "build" / "windows-private-runtime"
     assert layout.cache_dir == layout.build_dir / "cache"
-    assert layout.dist_dir == tmp_path / "dist" / "pyemsi-windows-portable"
+    assert layout.dist_dir == tmp_path / "dist" / "pyemsi"
     assert layout.runtime_dir == layout.dist_dir / "runtime"
     assert layout.app_dir == layout.dist_dir / "app"
+    assert layout.launcher_exe == layout.dist_dir / "pyemsi.exe"
+    assert layout.script_launcher_exe == layout.dist_dir / "run_script.exe"

--- a/tests/test_build_windows_private_runtime.py
+++ b/tests/test_build_windows_private_runtime.py
@@ -1,0 +1,122 @@
+"""Tests for the Windows private-runtime builder helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_builder_module():
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "build_windows_private_runtime.py"
+    spec = importlib.util.spec_from_file_location("build_windows_private_runtime", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+builder = _load_builder_module()
+
+
+def test_read_runtime_dependencies_merges_project_and_runtime_extras():
+    pyproject_data = {
+        "project": {"dependencies": ["numpy>=1.21.0", "PySide6>=6.5.0"]},
+        "tool": {
+            "pyemsi": {
+                "windows-private-runtime": {
+                    "extra_dependencies": ["PySide6>=6.5.0", "pywinpty", "PySide6>=6.5.0"],
+                }
+            }
+        },
+    }
+
+    dependencies = builder.read_runtime_dependencies(pyproject_data)
+
+    assert dependencies == ("numpy>=1.21.0", "PySide6>=6.5.0", "pywinpty")
+
+
+def test_read_runtime_dependencies_keeps_project_only_packages():
+    pyproject_data = {
+        "project": {"dependencies": ["scienceplots", "numpy>=1.21.0"]},
+        "tool": {
+            "pyemsi": {
+                "windows-private-runtime": {
+                    "extra_dependencies": ["numpy>=1.21.0", "pywinpty"],
+                }
+            }
+        },
+    }
+
+    dependencies = builder.read_runtime_dependencies(pyproject_data)
+
+    assert dependencies == ("scienceplots", "numpy>=1.21.0", "pywinpty")
+
+
+def test_read_app_module_prefers_runtime_tool_config():
+    pyproject_data = {
+        "tool": {
+            "pyemsi": {
+                "windows-private-runtime": {
+                    "app_module": "pyemsi.gui",
+                }
+            }
+        }
+    }
+
+    app_module = builder.read_app_module(pyproject_data, default="fallback.module")
+
+    assert app_module == "pyemsi.gui"
+
+
+def test_load_build_config_uses_runtime_tool_app_module(tmp_path):
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(
+        """
+[project]
+name = "pyemsi"
+dependencies = ["numpy>=1.21.0"]
+
+[tool.pyemsi.windows-private-runtime]
+app_module = "pyemsi.gui"
+extra_dependencies = ["pywinpty"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    config = builder.load_build_config(tmp_path, pyproject_path=pyproject_path)
+
+    assert config.app_module == "pyemsi.gui"
+    assert config.dependencies == ("numpy>=1.21.0", "pywinpty")
+
+
+def test_render_pth_text_enables_site_and_app_path_once():
+    original = "python311.zip\n.\n# import site\n"
+
+    rendered = builder.render_pth_text(original)
+
+    assert rendered.count("import site") == 1
+    assert rendered.count("..\\app") == 1
+    assert rendered.endswith("\n")
+
+
+def test_render_launcher_bat_targets_private_runtime_module():
+    launcher = builder.render_launcher_bat(app_module="pyemsi.gui")
+
+    assert "set PYTHONHOME=%BASE_DIR%runtime" in launcher
+    assert "set PYTHONPATH=%BASE_DIR%app" in launcher
+    assert "set PATH=%BASE_DIR%runtime;%BASE_DIR%runtime\\Scripts;%PATH%" in launcher
+    assert '"%BASE_DIR%runtime\\python.exe" -m pyemsi.gui %*' in launcher
+
+
+def test_build_layout_uses_scoped_output_directories(tmp_path):
+    layout = builder.build_layout(tmp_path)
+
+    assert layout.build_dir == tmp_path / "build" / "windows-private-runtime"
+    assert layout.cache_dir == layout.build_dir / "cache"
+    assert layout.dist_dir == tmp_path / "dist" / "pyemsi-windows-portable"
+    assert layout.runtime_dir == layout.dist_dir / "runtime"
+    assert layout.app_dir == layout.dist_dir / "app"

--- a/tools/build_windows_private_runtime.py
+++ b/tools/build_windows_private_runtime.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tomllib
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+DEFAULT_PYTHON_VERSION = "3.11.9"
+DEFAULT_DIST_NAME = "pyemsi-windows-portable"
+DEFAULT_APP_MODULE = "pyemsi.gui"
+WINDOWS_RUNTIME_TOOL_PATH = ("tool", "pyemsi", "windows-private-runtime")
+GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+
+
+@dataclass(frozen=True)
+class BuildLayout:
+    repo_root: Path
+    build_dir: Path
+    cache_dir: Path
+    dist_dir: Path
+    runtime_dir: Path
+    app_dir: Path
+    launcher_bat: Path
+    script_launcher_bat: Path
+
+
+@dataclass(frozen=True)
+class BuildConfig:
+    app_name: str
+    python_version: str
+    python_tag: str
+    app_module: str
+    dependencies: tuple[str, ...]
+    layout: BuildLayout
+
+    @property
+    def embed_zip_name(self) -> str:
+        return f"python-{self.python_version}-embed-amd64.zip"
+
+    @property
+    def embed_url(self) -> str:
+        return f"https://www.python.org/ftp/python/{self.python_version}/{self.embed_zip_name}"
+
+    @property
+    def pth_file(self) -> Path:
+        return self.layout.runtime_dir / f"python{self.python_tag}._pth"
+
+
+def build_layout(repo_root: Path, *, dist_name: str = DEFAULT_DIST_NAME) -> BuildLayout:
+    build_dir = repo_root / "build" / "windows-private-runtime"
+    cache_dir = build_dir / "cache"
+    dist_dir = repo_root / "dist" / dist_name
+    runtime_dir = dist_dir / "runtime"
+    app_dir = dist_dir / "app"
+    return BuildLayout(
+        repo_root=repo_root,
+        build_dir=build_dir,
+        cache_dir=cache_dir,
+        dist_dir=dist_dir,
+        runtime_dir=runtime_dir,
+        app_dir=app_dir,
+        launcher_bat=dist_dir / "run_pyemsi.bat",
+        script_launcher_bat=dist_dir / "run_script.bat",
+    )
+
+
+def load_pyproject(pyproject_path: Path) -> dict[str, Any]:
+    with pyproject_path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _get_nested_mapping(data: Mapping[str, Any], path: tuple[str, ...]) -> Mapping[str, Any]:
+    current: Mapping[str, Any] | Any = data
+    for key in path:
+        if not isinstance(current, Mapping):
+            return {}
+        current = current.get(key, {})
+    return current if isinstance(current, Mapping) else {}
+
+
+def read_app_name(pyproject_data: Mapping[str, Any]) -> str:
+    project_name = pyproject_data.get("project", {}).get("name")
+    if isinstance(project_name, str) and project_name.strip():
+        return project_name.strip()
+
+    return "pyemsi"
+
+
+def read_app_module(pyproject_data: Mapping[str, Any], *, default: str = DEFAULT_APP_MODULE) -> str:
+    runtime_config = _get_nested_mapping(pyproject_data, WINDOWS_RUNTIME_TOOL_PATH)
+    app_module = runtime_config.get("app_module")
+    if isinstance(app_module, str) and app_module.strip():
+        return app_module.strip()
+    return default
+
+
+def read_runtime_dependencies(pyproject_data: Mapping[str, Any]) -> tuple[str, ...]:
+    runtime_config = _get_nested_mapping(pyproject_data, WINDOWS_RUNTIME_TOOL_PATH)
+    extra_dependencies = runtime_config.get("extra_dependencies", [])
+    project_dependencies = pyproject_data.get("project", {}).get("dependencies", [])
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for item in [*project_dependencies, *extra_dependencies]:
+        if not isinstance(item, str):
+            continue
+        normalized = item.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(normalized)
+    return tuple(ordered)
+
+
+def load_build_config(
+    repo_root: Path,
+    *,
+    pyproject_path: Path | None = None,
+    python_version: str = DEFAULT_PYTHON_VERSION,
+    dist_name: str = DEFAULT_DIST_NAME,
+    app_module: str | None = None,
+) -> BuildConfig:
+    project_path = pyproject_path or repo_root / "pyproject.toml"
+    pyproject_data = load_pyproject(project_path)
+    python_tag = "".join(python_version.split(".")[:2])
+    resolved_app_module = app_module or read_app_module(pyproject_data)
+    return BuildConfig(
+        app_name=read_app_name(pyproject_data),
+        python_version=python_version,
+        python_tag=python_tag,
+        app_module=resolved_app_module,
+        dependencies=read_runtime_dependencies(pyproject_data),
+        layout=build_layout(repo_root, dist_name=dist_name),
+    )
+
+
+def render_pth_text(original_text: str, *, app_relative_path: str = r"..\app") -> str:
+    lines = original_text.splitlines()
+    output: list[str] = []
+    has_import_site = False
+    has_app_path = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped in {"#import site", "# import site", "import site"}:
+            output.append("import site")
+            has_import_site = True
+            continue
+        if stripped == app_relative_path:
+            has_app_path = True
+        output.append(line)
+
+    if not has_import_site:
+        output.append("import site")
+    if not has_app_path:
+        output.append(app_relative_path)
+
+    return "\n".join(output) + "\n"
+
+
+def render_launcher_bat(*, app_module: str, runtime_dir_name: str = "runtime", app_dir_name: str = "app") -> str:
+    lines = [
+        "@echo off",
+        "setlocal",
+        "set BASE_DIR=%~dp0",
+        f"set PYTHONHOME=%BASE_DIR%{runtime_dir_name}",
+        f"set PYTHONPATH=%BASE_DIR%{app_dir_name}",
+        f"set PATH=%BASE_DIR%{runtime_dir_name};%BASE_DIR%{runtime_dir_name}\\Scripts;%PATH%",
+        f'"%BASE_DIR%{runtime_dir_name}\\python.exe" -m {app_module} %*',
+        "",
+    ]
+    return "\r\n".join(lines)
+
+
+def render_script_launcher_bat(*, runtime_dir_name: str = "runtime", app_dir_name: str = "app") -> str:
+    lines = [
+        "@echo off",
+        "setlocal",
+        "set BASE_DIR=%~dp0",
+        'if "%~1"=="" (',
+        "  echo Usage: run_script.bat path\\to\\script.py [args...]",
+        "  exit /b 1",
+        ")",
+        "set SCRIPT=%~1",
+        "shift",
+        f"set PYTHONHOME=%BASE_DIR%{runtime_dir_name}",
+        f"set PYTHONPATH=%BASE_DIR%{app_dir_name}",
+        f"set PATH=%BASE_DIR%{runtime_dir_name};%BASE_DIR%{runtime_dir_name}\\Scripts;%PATH%",
+        f'"%BASE_DIR%{runtime_dir_name}\\python.exe" "%SCRIPT%" %*',
+        "",
+    ]
+    return "\r\n".join(lines)
+
+
+def ensure_runtime_source_artifacts(repo_root: Path) -> None:
+    extension_matches = list((repo_root / "pyemsi" / "core").glob("femap_parser*.pyd"))
+    if not extension_matches:
+        raise FileNotFoundError(
+            "Missing compiled femap_parser extension under pyemsi/core. "
+            "Run `python setup.py build_ext --inplace` before packaging."
+        )
+
+    resources_module = repo_root / "pyemsi" / "resources" / "resources.py"
+    if not resources_module.is_file():
+        raise FileNotFoundError(
+            "Missing compiled Qt resource module pyemsi/resources/resources.py. Regenerate it before packaging."
+        )
+
+    launcher_module = repo_root / "pyemsi" / "gui" / "__main__.py"
+    if not launcher_module.is_file():
+        raise FileNotFoundError("Missing pyemsi/gui/__main__.py launcher module.")
+
+
+def reset_output_directories(layout: BuildLayout) -> None:
+    layout.dist_dir.mkdir(parents=True, exist_ok=True)
+    for path in (layout.runtime_dir, layout.app_dir):
+        if path.exists():
+            shutil.rmtree(path)
+    for path in (layout.launcher_bat, layout.script_launcher_bat):
+        if path.exists():
+            path.unlink()
+    layout.cache_dir.mkdir(parents=True, exist_ok=True)
+    layout.runtime_dir.mkdir(parents=True, exist_ok=True)
+    layout.app_dir.mkdir(parents=True, exist_ok=True)
+
+
+def download_file(url: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    urllib.request.urlretrieve(url, destination)
+
+
+def extract_embed_runtime(zip_path: Path, destination: Path) -> None:
+    with zipfile.ZipFile(zip_path) as archive:
+        archive.extractall(destination)
+
+
+def patch_pth_file(pth_path: Path) -> None:
+    original_text = pth_path.read_text(encoding="ascii")
+    pth_path.write_text(render_pth_text(original_text), encoding="ascii")
+
+
+def copy_application_source(repo_root: Path, app_dir: Path) -> None:
+    for package_name in ("pyemsi",):
+        source = repo_root / package_name
+        destination = app_dir / package_name
+        shutil.copytree(source, destination, ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"))
+
+
+def run_checked(command: Iterable[str], *, cwd: Path | None = None) -> None:
+    subprocess.run(list(command), cwd=cwd, check=True)
+
+
+def install_runtime_dependencies(config: BuildConfig) -> None:
+    get_pip_path = config.layout.cache_dir / "get-pip.py"
+    if not get_pip_path.exists():
+        download_file(GET_PIP_URL, get_pip_path)
+
+    python_exe = config.layout.runtime_dir / "python.exe"
+    run_checked([str(python_exe), str(get_pip_path), "--no-warn-script-location"])
+    run_checked([str(python_exe), "-m", "pip", "install", "--upgrade", "pip"])
+    if config.dependencies:
+        run_checked([str(python_exe), "-m", "pip", "install", *config.dependencies])
+
+
+def write_launchers(config: BuildConfig) -> None:
+    config.layout.launcher_bat.write_text(render_launcher_bat(app_module=config.app_module), encoding="ascii")
+    config.layout.script_launcher_bat.write_text(render_script_launcher_bat(), encoding="ascii")
+
+
+def smoke_test(config: BuildConfig) -> None:
+    python_exe = config.layout.runtime_dir / "python.exe"
+    run_checked(
+        [
+            str(python_exe),
+            "-c",
+            (
+                "import os, shutil, sys, pyemsi, PySide6, scienceplots;"
+                "scripts_dir=os.path.join(os.path.dirname(sys.executable), 'Scripts');"
+                "os.environ['PATH']=os.pathsep.join([os.path.dirname(sys.executable), scripts_dir, os.environ.get('PATH', '')]);"
+                "assert shutil.which('basedpyright-langserver');"
+                "assert shutil.which('pylsp');"
+                "print(sys.executable);"
+                "print(pyemsi.__version__);"
+                "print(scienceplots.__file__)"
+            ),
+        ],
+        cwd=config.layout.dist_dir,
+    )
+
+
+def build_private_runtime(
+    config: BuildConfig,
+    *,
+    install_dependencies_flag: bool = True,
+    run_smoke_test: bool = True,
+) -> BuildConfig:
+    ensure_runtime_source_artifacts(config.layout.repo_root)
+    reset_output_directories(config.layout)
+
+    embed_zip_path = config.layout.cache_dir / config.embed_zip_name
+    if not embed_zip_path.exists():
+        download_file(config.embed_url, embed_zip_path)
+
+    extract_embed_runtime(embed_zip_path, config.layout.runtime_dir)
+    if not config.pth_file.is_file():
+        raise FileNotFoundError(f"Embedded runtime ._pth file not found: {config.pth_file}")
+    patch_pth_file(config.pth_file)
+    copy_application_source(config.layout.repo_root, config.layout.app_dir)
+
+    if install_dependencies_flag:
+        install_runtime_dependencies(config)
+
+    write_launchers(config)
+
+    if run_smoke_test:
+        smoke_test(config)
+
+    return config
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build a Windows portable pyemsi runtime.")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--python-version", default=DEFAULT_PYTHON_VERSION)
+    parser.add_argument("--dist-name", default=DEFAULT_DIST_NAME)
+    parser.add_argument("--app-module")
+    parser.add_argument("--skip-dependency-install", action="store_true")
+    parser.add_argument("--skip-smoke-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    if sys.platform != "win32":
+        print("This build script currently supports Windows only.", file=sys.stderr)
+        return 1
+
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    config = load_build_config(
+        repo_root,
+        python_version=args.python_version,
+        dist_name=args.dist_name,
+        app_module=args.app_module,
+    )
+    build_private_runtime(
+        config,
+        install_dependencies_flag=not args.skip_dependency_install,
+        run_smoke_test=not args.skip_smoke_test,
+    )
+    print(f"Build completed: {config.layout.dist_dir}")
+    print(f"Launcher: {config.layout.launcher_bat}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/build_windows_private_runtime.py
+++ b/tools/build_windows_private_runtime.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import subprocess
 import sys
+import textwrap
 import tomllib
 import urllib.request
 import zipfile
@@ -12,10 +14,76 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 DEFAULT_PYTHON_VERSION = "3.11.9"
-DEFAULT_DIST_NAME = "pyemsi-windows-portable"
+DEFAULT_DIST_NAME = "pyemsi"
 DEFAULT_APP_MODULE = "pyemsi.gui"
-WINDOWS_RUNTIME_TOOL_PATH = ("tool", "pyemsi", "windows-private-runtime")
+_RUNTIME_TOOL_KEY = ("tool", "pyemsi", "windows-private-runtime")
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+
+_REQUIRED_ARTIFACTS = [
+    ("pyemsi/core/femap_parser*.pyd", "Run `python setup.py build_ext --inplace` before packaging."),
+    ("pyemsi/resources/resources.py", "Regenerate the Qt resource module before packaging."),
+    ("pyemsi/gui/__main__.py", "Missing GUI launcher module."),
+]
+
+_SMOKE_TEST_SCRIPT = textwrap.dedent("""\
+    import os, shutil, sys, pyemsi, PySide6, scienceplots
+    scripts_dir = os.path.join(os.path.dirname(sys.executable), "Scripts")
+    os.environ["PATH"] = os.pathsep.join([
+        os.path.dirname(sys.executable), scripts_dir,
+        os.environ.get("PATH", ""),
+    ])
+    assert shutil.which("basedpyright-langserver")
+    assert shutil.which("pylsp")
+    print(sys.executable)
+    print(pyemsi.__version__)
+    print(scienceplots.__file__)
+""")
+
+
+LAUNCHER_C_SOURCE = Path(__file__).resolve().parent / "launcher.c"
+LAUNCHER_ICO = Path(__file__).resolve().parents[1] / "pyemsi" / "resources" / "icons" / "Icon.ico"
+
+
+def _render_rc(*, version_str: str, ico_path: Path | None) -> str:
+    """Generate a Win32 .rc resource script with VERSIONINFO and icon."""
+    parts = (version_str + ".0.0.0").split(".")[:4]
+    ver_csv = ",".join(parts[:4])
+    lines = [
+        "#include <winver.h>",
+        "",
+    ]
+    if ico_path and ico_path.is_file():
+        lines.append(f'1 ICON "{ico_path.as_posix()}"')
+        lines.append("")
+    lines += [
+        "VS_VERSION_INFO VERSIONINFO",
+        f" FILEVERSION {ver_csv}",
+        f" PRODUCTVERSION {ver_csv}",
+        " FILEFLAGSMASK VS_FFI_FILEFLAGSMASK",
+        " FILEFLAGS 0x0",
+        " FILEOS VOS_NT_WINDOWS32",
+        " FILETYPE VFT_APP",
+        " FILESUBTYPE 0x0",
+        "BEGIN",
+        '  BLOCK "StringFileInfo"',
+        "  BEGIN",
+        '    BLOCK "040904B0"',
+        "    BEGIN",
+        '      VALUE "FileDescription", "pyemsi - EMSolution Visualization"',
+        f'      VALUE "FileVersion", "{version_str}"',
+        '      VALUE "ProductName", "pyemsi"',
+        f'      VALUE "ProductVersion", "{version_str}"',
+        '      VALUE "LegalCopyright", "Copyright \\251 SSIL"',
+        '      VALUE "OriginalFilename", "pyemsi.exe"',
+        "    END",
+        "  END",
+        '  BLOCK "VarFileInfo"',
+        "  BEGIN",
+        '    VALUE "Translation", 0x0409, 0x04B0',
+        "  END",
+        "END",
+    ]
+    return "\n".join(lines) + "\n"
 
 
 @dataclass(frozen=True)
@@ -28,6 +96,8 @@ class BuildLayout:
     app_dir: Path
     launcher_bat: Path
     script_launcher_bat: Path
+    launcher_exe: Path
+    script_launcher_exe: Path
 
 
 @dataclass(frozen=True)
@@ -65,8 +135,10 @@ def build_layout(repo_root: Path, *, dist_name: str = DEFAULT_DIST_NAME) -> Buil
         dist_dir=dist_dir,
         runtime_dir=runtime_dir,
         app_dir=app_dir,
-        launcher_bat=dist_dir / "run_pyemsi.bat",
+        launcher_bat=dist_dir / "pyemsi.bat",
         script_launcher_bat=dist_dir / "run_script.bat",
+        launcher_exe=dist_dir / "pyemsi.exe",
+        script_launcher_exe=dist_dir / "run_script.exe",
     )
 
 
@@ -75,39 +147,19 @@ def load_pyproject(pyproject_path: Path) -> dict[str, Any]:
         return tomllib.load(handle)
 
 
-def _get_nested_mapping(data: Mapping[str, Any], path: tuple[str, ...]) -> Mapping[str, Any]:
-    current: Mapping[str, Any] | Any = data
-    for key in path:
+def _get_nested(data: Mapping[str, Any], *keys: str) -> Any:
+    current: Any = data
+    for key in keys:
         if not isinstance(current, Mapping):
             return {}
         current = current.get(key, {})
-    return current if isinstance(current, Mapping) else {}
+    return current
 
 
-def read_app_name(pyproject_data: Mapping[str, Any]) -> str:
-    project_name = pyproject_data.get("project", {}).get("name")
-    if isinstance(project_name, str) and project_name.strip():
-        return project_name.strip()
-
-    return "pyemsi"
-
-
-def read_app_module(pyproject_data: Mapping[str, Any], *, default: str = DEFAULT_APP_MODULE) -> str:
-    runtime_config = _get_nested_mapping(pyproject_data, WINDOWS_RUNTIME_TOOL_PATH)
-    app_module = runtime_config.get("app_module")
-    if isinstance(app_module, str) and app_module.strip():
-        return app_module.strip()
-    return default
-
-
-def read_runtime_dependencies(pyproject_data: Mapping[str, Any]) -> tuple[str, ...]:
-    runtime_config = _get_nested_mapping(pyproject_data, WINDOWS_RUNTIME_TOOL_PATH)
-    extra_dependencies = runtime_config.get("extra_dependencies", [])
-    project_dependencies = pyproject_data.get("project", {}).get("dependencies", [])
-
+def _unique_strings(items: Iterable[Any]) -> tuple[str, ...]:
     ordered: list[str] = []
     seen: set[str] = set()
-    for item in [*project_dependencies, *extra_dependencies]:
+    for item in items:
         if not isinstance(item, str):
             continue
         normalized = item.strip()
@@ -126,16 +178,35 @@ def load_build_config(
     dist_name: str = DEFAULT_DIST_NAME,
     app_module: str | None = None,
 ) -> BuildConfig:
-    project_path = pyproject_path or repo_root / "pyproject.toml"
-    pyproject_data = load_pyproject(project_path)
+    pyproject_data = load_pyproject(pyproject_path or repo_root / "pyproject.toml")
+    runtime_config = _get_nested(pyproject_data, *_RUNTIME_TOOL_KEY)
+    runtime_config = runtime_config if isinstance(runtime_config, Mapping) else {}
+
+    project_name = _get_nested(pyproject_data, "project", "name")
+    app_name = project_name.strip() if isinstance(project_name, str) and project_name.strip() else "pyemsi"
+
+    if app_module is None:
+        configured_module = runtime_config.get("app_module")
+        app_module = (
+            configured_module.strip()
+            if isinstance(configured_module, str) and configured_module.strip()
+            else DEFAULT_APP_MODULE
+        )
+
+    project_deps = _get_nested(pyproject_data, "project", "dependencies")
+    extra_deps = runtime_config.get("extra_dependencies", [])
+    all_deps = [
+        *(project_deps if isinstance(project_deps, list) else []),
+        *(extra_deps if isinstance(extra_deps, list) else []),
+    ]
+
     python_tag = "".join(python_version.split(".")[:2])
-    resolved_app_module = app_module or read_app_module(pyproject_data)
     return BuildConfig(
-        app_name=read_app_name(pyproject_data),
+        app_name=app_name,
         python_version=python_version,
         python_tag=python_tag,
-        app_module=resolved_app_module,
-        dependencies=read_runtime_dependencies(pyproject_data),
+        app_module=app_module,
+        dependencies=_unique_strings(all_deps),
         layout=build_layout(repo_root, dist_name=dist_name),
     )
 
@@ -164,80 +235,50 @@ def render_pth_text(original_text: str, *, app_relative_path: str = r"..\app") -
     return "\n".join(output) + "\n"
 
 
-def render_launcher_bat(*, app_module: str, runtime_dir_name: str = "runtime", app_dir_name: str = "app") -> str:
-    lines = [
-        "@echo off",
-        "setlocal",
-        "set BASE_DIR=%~dp0",
+def render_launcher_bat(
+    *,
+    app_module: str | None = None,
+    script_mode: bool = False,
+    runtime_dir_name: str = "runtime",
+    app_dir_name: str = "app",
+) -> str:
+    lines = ["@echo off", "setlocal", "set BASE_DIR=%~dp0"]
+    if script_mode:
+        lines += [
+            'if "%~1"=="" (',
+            "  echo Usage: run_script.bat path\\to\\script.py [args...]",
+            "  exit /b 1",
+            ")",
+            "set SCRIPT=%~1",
+            "shift",
+        ]
+    lines += [
         f"set PYTHONHOME=%BASE_DIR%{runtime_dir_name}",
         f"set PYTHONPATH=%BASE_DIR%{app_dir_name}",
         f"set PATH=%BASE_DIR%{runtime_dir_name};%BASE_DIR%{runtime_dir_name}\\Scripts;%PATH%",
-        f'"%BASE_DIR%{runtime_dir_name}\\python.exe" -m {app_module} %*',
-        "",
     ]
-    return "\r\n".join(lines)
-
-
-def render_script_launcher_bat(*, runtime_dir_name: str = "runtime", app_dir_name: str = "app") -> str:
-    lines = [
-        "@echo off",
-        "setlocal",
-        "set BASE_DIR=%~dp0",
-        'if "%~1"=="" (',
-        "  echo Usage: run_script.bat path\\to\\script.py [args...]",
-        "  exit /b 1",
-        ")",
-        "set SCRIPT=%~1",
-        "shift",
-        f"set PYTHONHOME=%BASE_DIR%{runtime_dir_name}",
-        f"set PYTHONPATH=%BASE_DIR%{app_dir_name}",
-        f"set PATH=%BASE_DIR%{runtime_dir_name};%BASE_DIR%{runtime_dir_name}\\Scripts;%PATH%",
-        f'"%BASE_DIR%{runtime_dir_name}\\python.exe" "%SCRIPT%" %*',
-        "",
-    ]
+    if script_mode:
+        lines.append(f'"%BASE_DIR%{runtime_dir_name}\\python.exe" "%SCRIPT%" %*')
+    else:
+        lines.append(f'"%BASE_DIR%{runtime_dir_name}\\python.exe" -m {app_module} %*')
+    lines.append("")
     return "\r\n".join(lines)
 
 
 def ensure_runtime_source_artifacts(repo_root: Path) -> None:
-    extension_matches = list((repo_root / "pyemsi" / "core").glob("femap_parser*.pyd"))
-    if not extension_matches:
-        raise FileNotFoundError(
-            "Missing compiled femap_parser extension under pyemsi/core. "
-            "Run `python setup.py build_ext --inplace` before packaging."
-        )
-
-    resources_module = repo_root / "pyemsi" / "resources" / "resources.py"
-    if not resources_module.is_file():
-        raise FileNotFoundError(
-            "Missing compiled Qt resource module pyemsi/resources/resources.py. Regenerate it before packaging."
-        )
-
-    launcher_module = repo_root / "pyemsi" / "gui" / "__main__.py"
-    if not launcher_module.is_file():
-        raise FileNotFoundError("Missing pyemsi/gui/__main__.py launcher module.")
+    for pattern, message in _REQUIRED_ARTIFACTS:
+        if "*" in pattern:
+            if not list(repo_root.glob(pattern)):
+                raise FileNotFoundError(f"Missing {pattern}. {message}")
+        elif not (repo_root / pattern).is_file():
+            raise FileNotFoundError(f"Missing {pattern}. {message}")
 
 
 def reset_output_directories(layout: BuildLayout) -> None:
-    layout.dist_dir.mkdir(parents=True, exist_ok=True)
-    for path in (layout.runtime_dir, layout.app_dir):
-        if path.exists():
-            shutil.rmtree(path)
-    for path in (layout.launcher_bat, layout.script_launcher_bat):
-        if path.exists():
-            path.unlink()
-    layout.cache_dir.mkdir(parents=True, exist_ok=True)
-    layout.runtime_dir.mkdir(parents=True, exist_ok=True)
-    layout.app_dir.mkdir(parents=True, exist_ok=True)
-
-
-def download_file(url: str, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    urllib.request.urlretrieve(url, destination)
-
-
-def extract_embed_runtime(zip_path: Path, destination: Path) -> None:
-    with zipfile.ZipFile(zip_path) as archive:
-        archive.extractall(destination)
+    if layout.dist_dir.exists():
+        shutil.rmtree(layout.dist_dir)
+    for path in (layout.dist_dir, layout.runtime_dir, layout.app_dir, layout.cache_dir):
+        path.mkdir(parents=True, exist_ok=True)
 
 
 def patch_pth_file(pth_path: Path) -> None:
@@ -259,7 +300,8 @@ def run_checked(command: Iterable[str], *, cwd: Path | None = None) -> None:
 def install_runtime_dependencies(config: BuildConfig) -> None:
     get_pip_path = config.layout.cache_dir / "get-pip.py"
     if not get_pip_path.exists():
-        download_file(GET_PIP_URL, get_pip_path)
+        get_pip_path.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(GET_PIP_URL, get_pip_path)
 
     python_exe = config.layout.runtime_dir / "python.exe"
     run_checked([str(python_exe), str(get_pip_path), "--no-warn-script-location"])
@@ -268,30 +310,160 @@ def install_runtime_dependencies(config: BuildConfig) -> None:
         run_checked([str(python_exe), "-m", "pip", "install", *config.dependencies])
 
 
+# ── Native .exe launcher compilation ─────────────────────────────────────
+
+
+def _find_vcvarsall() -> Path | None:
+    """Locate vcvarsall.bat via vswhere (ships with VS 2017+)."""
+    program_files = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    vswhere = Path(program_files) / "Microsoft Visual Studio" / "Installer" / "vswhere.exe"
+    if not vswhere.is_file():
+        return None
+    try:
+        result = subprocess.run(
+            [
+                str(vswhere),
+                "-latest",
+                "-property",
+                "installationPath",
+                "-requires",
+                "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        vcvarsall = Path(result.stdout.strip()) / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat"
+        return vcvarsall if vcvarsall.is_file() else None
+    except Exception:
+        return None
+
+
+def _compile_native_launcher(
+    source: Path,
+    output_exe: Path,
+    *,
+    defines: list[str] | None = None,
+    gui: bool = False,
+    rc_file: Path | None = None,
+) -> bool:
+    """Compile *source* to *output_exe* with MSVC.  Returns True on success."""
+
+    def _try_compile(*, use_vcvarsall: Path | None = None) -> bool:
+        """Run the compilation.  If *use_vcvarsall* is given, prefix with it."""
+        # --- resource compiler -------------------------------------------
+        res_file: Path | None = None
+        if rc_file and rc_file.is_file():
+            res_file = rc_file.with_suffix(".res")
+            rc_args = ["rc", "/nologo", f"/fo{res_file}", str(rc_file)]
+            if use_vcvarsall:
+                rc_cmd = f'"{use_vcvarsall}" amd64 && {subprocess.list2cmdline(rc_args)}'
+                r = subprocess.run(
+                    rc_cmd, shell=True, capture_output=True, text=True, timeout=60, cwd=str(output_exe.parent)
+                )
+            else:
+                r = subprocess.run(rc_args, capture_output=True, text=True, timeout=60, cwd=str(output_exe.parent))
+            if r.returncode != 0:
+                res_file = None  # skip linking the resource
+
+        # --- C compiler --------------------------------------------------
+        cl_args = ["cl", "/nologo", "/O2", "/W3"]
+        for d in defines or []:
+            cl_args.append(f"/D{d}")
+        cl_args.append(str(source))
+        if res_file and res_file.is_file():
+            cl_args.append(str(res_file))
+        cl_args.append(f"/Fe:{output_exe}")
+        link_flags = []
+        if gui:
+            link_flags += ["/SUBSYSTEM:WINDOWS", "/ENTRY:wmainCRTStartup"]
+        if link_flags:
+            cl_args += ["/link"] + link_flags
+
+        if use_vcvarsall:
+            cl_cmd = subprocess.list2cmdline(cl_args)
+            shell_cmd = f'"{use_vcvarsall}" amd64 && {cl_cmd}'
+            r = subprocess.run(
+                shell_cmd, shell=True, capture_output=True, text=True, timeout=60, cwd=str(output_exe.parent)
+            )
+        else:
+            r = subprocess.run(cl_args, capture_output=True, text=True, timeout=60, cwd=str(output_exe.parent))
+        return r.returncode == 0 and output_exe.is_file()
+
+    # Try cl.exe directly (works inside a Developer Command Prompt).
+    if shutil.which("cl"):
+        try:
+            if _try_compile():
+                return True
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Fall back: locate vcvarsall, set up MSVC env, then compile.
+    vcvarsall = _find_vcvarsall()
+    if vcvarsall is None:
+        return False
+    try:
+        return _try_compile(use_vcvarsall=vcvarsall)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _cleanup_compiler_artifacts(directory: Path) -> None:
+    """Remove .obj and .res files left behind by cl.exe / rc.exe."""
+    for pattern in ("launcher*.obj", "*.res", "*.rc"):
+        for f in directory.glob(pattern):
+            f.unlink(missing_ok=True)
+
+
+def compile_native_launchers(config: BuildConfig) -> bool:
+    """Compile both .exe launchers.  Returns True if both succeeded."""
+    if not LAUNCHER_C_SOURCE.is_file():
+        print(f"Launcher C source not found: {LAUNCHER_C_SOURCE}", file=sys.stderr)
+        return False
+
+    version_str = "0.1.3"
+    rc_path = config.layout.dist_dir / "launcher.rc"
+    rc_path.write_text(
+        _render_rc(version_str=version_str, ico_path=LAUNCHER_ICO),
+        encoding="utf-8",
+    )
+
+    app_ok = _compile_native_launcher(
+        LAUNCHER_C_SOURCE,
+        config.layout.launcher_exe,
+        defines=[f'APP_MODULE="{config.app_module}"', "NO_CONSOLE"],
+        gui=True,
+        rc_file=rc_path,
+    )
+    script_ok = _compile_native_launcher(
+        LAUNCHER_C_SOURCE,
+        config.layout.script_launcher_exe,
+        defines=["SCRIPT_MODE"],
+        gui=False,
+    )
+    _cleanup_compiler_artifacts(config.layout.dist_dir)
+    return app_ok and script_ok
+
+
 def write_launchers(config: BuildConfig) -> None:
-    config.layout.launcher_bat.write_text(render_launcher_bat(app_module=config.app_module), encoding="ascii")
-    config.layout.script_launcher_bat.write_text(render_script_launcher_bat(), encoding="ascii")
+    exe_ok = compile_native_launchers(config)
+    if exe_ok:
+        print("Compiled native .exe launchers.")
+    else:
+        print("MSVC not available — falling back to .bat launchers.", file=sys.stderr)
+        config.layout.launcher_bat.write_text(
+            render_launcher_bat(app_module=config.app_module),
+            encoding="ascii",
+        )
+        config.layout.script_launcher_bat.write_text(
+            render_launcher_bat(script_mode=True),
+            encoding="ascii",
+        )
 
 
 def smoke_test(config: BuildConfig) -> None:
     python_exe = config.layout.runtime_dir / "python.exe"
-    run_checked(
-        [
-            str(python_exe),
-            "-c",
-            (
-                "import os, shutil, sys, pyemsi, PySide6, scienceplots;"
-                "scripts_dir=os.path.join(os.path.dirname(sys.executable), 'Scripts');"
-                "os.environ['PATH']=os.pathsep.join([os.path.dirname(sys.executable), scripts_dir, os.environ.get('PATH', '')]);"
-                "assert shutil.which('basedpyright-langserver');"
-                "assert shutil.which('pylsp');"
-                "print(sys.executable);"
-                "print(pyemsi.__version__);"
-                "print(scienceplots.__file__)"
-            ),
-        ],
-        cwd=config.layout.dist_dir,
-    )
+    run_checked([str(python_exe), "-c", _SMOKE_TEST_SCRIPT], cwd=config.layout.dist_dir)
 
 
 def build_private_runtime(
@@ -305,9 +477,11 @@ def build_private_runtime(
 
     embed_zip_path = config.layout.cache_dir / config.embed_zip_name
     if not embed_zip_path.exists():
-        download_file(config.embed_url, embed_zip_path)
+        embed_zip_path.parent.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(config.embed_url, embed_zip_path)
 
-    extract_embed_runtime(embed_zip_path, config.layout.runtime_dir)
+    with zipfile.ZipFile(embed_zip_path) as archive:
+        archive.extractall(config.layout.runtime_dir)
     if not config.pth_file.is_file():
         raise FileNotFoundError(f"Embedded runtime ._pth file not found: {config.pth_file}")
     patch_pth_file(config.pth_file)
@@ -354,7 +528,8 @@ def main() -> int:
         run_smoke_test=not args.skip_smoke_test,
     )
     print(f"Build completed: {config.layout.dist_dir}")
-    print(f"Launcher: {config.layout.launcher_bat}")
+    launcher = config.layout.launcher_exe if config.layout.launcher_exe.is_file() else config.layout.launcher_bat
+    print(f"Launcher: {launcher}")
     return 0
 
 

--- a/tools/launcher.c
+++ b/tools/launcher.c
@@ -1,0 +1,122 @@
+/*
+ * Minimal native launcher for the pyemsi Windows portable runtime.
+ *
+ * Compile with MSVC (the builder does this automatically):
+ *
+ *   GUI app launcher (no console window):
+ *     cl /nologo /O2 /DNO_CONSOLE launcher.c /Fe:pyemsi.exe
+ *        /link /SUBSYSTEM:WINDOWS /ENTRY:wmainCRTStartup
+ *
+ *   Script runner (console window):
+ *     cl /nologo /O2 /DSCRIPT_MODE launcher.c /Fe:run_script.exe
+ */
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <stdio.h>
+
+#ifndef APP_MODULE
+#define APP_MODULE "pyemsi.gui"
+#endif
+#define _WIDEN2(s) L##s
+#define _WIDEN(s) _WIDEN2(s)
+
+static BOOL get_base_dir(wchar_t *buf, DWORD len) {
+    DWORD n = GetModuleFileNameW(NULL, buf, len);
+    if (n == 0 || n >= len) return FALSE;
+    wchar_t *sep = wcsrchr(buf, L'\\');
+    if (sep) *(sep + 1) = L'\0';
+    return TRUE;
+}
+
+static void setup_environment(const wchar_t *base) {
+    wchar_t val[4096];
+
+    _snwprintf_s(val, 4096, _TRUNCATE, L"%sruntime", base);
+    SetEnvironmentVariableW(L"PYTHONHOME", val);
+
+    _snwprintf_s(val, 4096, _TRUNCATE, L"%sapp", base);
+    SetEnvironmentVariableW(L"PYTHONPATH", val);
+
+    wchar_t old_path[4096] = {0};
+    GetEnvironmentVariableW(L"PATH", old_path, 4096);
+    _snwprintf_s(val, 4096, _TRUNCATE,
+                 L"%sruntime;%sruntime\\Scripts;%s",
+                 base, base, old_path);
+    SetEnvironmentVariableW(L"PATH", val);
+}
+
+int wmain(int argc, wchar_t *argv[]) {
+    wchar_t base[MAX_PATH];
+    if (!get_base_dir(base, MAX_PATH)) {
+        fwprintf(stderr, L"Failed to resolve launcher directory.\n");
+        return 1;
+    }
+    setup_environment(base);
+
+    wchar_t python[MAX_PATH];
+    _snwprintf_s(python, MAX_PATH, _TRUNCATE, L"%sruntime\\python.exe", base);
+
+    /* ── Build command line ──────────────────────────────── */
+    wchar_t cmdline[8192];
+    int pos;
+
+#ifdef SCRIPT_MODE
+    if (argc < 2) {
+        fwprintf(stderr, L"Usage: %s <script.py> [args...]\n", argv[0]);
+        return 1;
+    }
+    pos = _snwprintf_s(cmdline, 8192, _TRUNCATE,
+                       L"\"%s\" \"%s\"", python, argv[1]);
+    for (int i = 2; i < argc && pos > 0 && pos < 8191; i++)
+        pos += _snwprintf_s(cmdline + pos, 8192 - pos, _TRUNCATE,
+                            L" \"%s\"", argv[i]);
+#else
+    pos = _snwprintf_s(cmdline, 8192, _TRUNCATE,
+                       L"\"%s\" -m %s", python, _WIDEN(APP_MODULE));
+    for (int i = 1; i < argc && pos > 0 && pos < 8191; i++)
+        pos += _snwprintf_s(cmdline + pos, 8192 - pos, _TRUNCATE,
+                            L" \"%s\"", argv[i]);
+#endif
+
+    /* ── Spawn python and wait ──────────────────────────── */
+    STARTUPINFOW si = { .cb = sizeof(si) };
+    PROCESS_INFORMATION pi = {0};
+
+    /* Create a job object so that all child processes (LSP servers, etc.)
+       are automatically terminated when the launcher exits.              */
+    HANDLE job = CreateJobObjectW(NULL, NULL);
+    if (job) {
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = {0};
+        jeli.BasicLimitInformation.LimitFlags =
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+                                &jeli, sizeof(jeli));
+    }
+
+    DWORD flags = CREATE_SUSPENDED;
+#ifdef NO_CONSOLE
+    flags |= CREATE_NO_WINDOW;
+#endif
+
+    if (!CreateProcessW(python, cmdline, NULL, NULL, TRUE,
+                        flags, NULL, NULL, &si, &pi)) {
+        fwprintf(stderr, L"Failed to start Python (error %lu).\n",
+                 GetLastError());
+        if (job) CloseHandle(job);
+        return 1;
+    }
+
+    if (job) AssignProcessToJobObject(job, pi.hProcess);
+    ResumeThread(pi.hThread);
+
+    WaitForSingleObject(pi.hProcess, INFINITE);
+    DWORD exit_code = 1;
+    GetExitCodeProcess(pi.hProcess, &exit_code);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    if (job) CloseHandle(job);   /* kills all remaining child processes */
+    return (int)exit_code;
+}


### PR DESCRIPTION
## Summary

This branch removes the Briefcase-based Windows packaging flow and replaces it with a repository-owned packaging pipeline for pyemsi.

The new flow builds a portable Windows distribution by downloading the CPython 3.11 embeddable runtime, staging the local pyemsi application next to that runtime, installing the application dependencies into the packaged runtime, and generating launchers for the GUI and script execution paths. On top of that portable layout, the branch adds an NSIS installer for a per-user Windows installation.

## Motivation

The previous Briefcase flow introduced an extra packaging layer and a generated app structure that was harder to reason about and maintain inside this repository. This branch moves packaging logic into repo-owned scripts and config so that:

- the runtime layout is explicit and reproducible from source control
- the packaged app keeps a real bundled Python runtime available for subprocess and script-based workflows
- Windows packaging behavior can be tested and documented directly in this repository
- installer generation is controlled by a plain NSIS script instead of a generated Briefcase artifact pipeline

## What Changed

### 1. Removed the Briefcase packaging path

- Removed the Briefcase-specific app wrapper package used for packaging.
- Removed the repo-owned Briefcase packaging configuration and the packaging flow that depended on Briefcase-managed Windows app scaffolding.
- Standardized GUI entry to use the existing pyemsi package directly instead of a separate packaging-only app package.

### 2. Added a built-in Windows private-runtime packager

A new builder was added at tools/build_windows_private_runtime.py.

This script now owns the Windows portable packaging flow:

- reads packaging configuration from [tool.pyemsi.windows-private-runtime] in pyproject.toml
- defaults to packaging pyemsi.gui as the application entry module
- downloads the official CPython 3.11 embeddable distribution from python.org
- extracts the runtime into dist/pyemsi/runtime
- patches the embedded runtime ._pth file to enable import site and add the packaged app directory to sys.path
- copies the local pyemsi source tree into dist/pyemsi/app
- installs the project dependencies into the bundled runtime with pip bootstrapped via get-pip.py
- merges the main project dependencies with packaging-only extra dependencies, currently including pywinpty
- runs a packaging smoke test against the staged runtime unless explicitly skipped

The builder also validates required in-repo artifacts before packaging starts, including:

- the in-place compiled Cython extension for pyemsi.core.femap_parser
- the generated Qt resource module
- the GUI module entry point

### 3. Added native Windows launcher generation

This branch adds tools/launcher.c and extends the builder to generate native launchers for the packaged runtime.

When MSVC is available:

- the builder compiles a GUI launcher executable for pyemsi
- the builder compiles a companion script launcher executable
- the GUI launcher is linked as a Windows subsystem application so the packaged app can start without opening a console window
- version and icon metadata are embedded through a generated .rc resource script

When MSVC is not available, the builder falls back to .bat launchers so packaging still remains usable.

This keeps the distribution self-contained while preserving access to runtime/python.exe for workflows that depend on a real Python executable.

### 4. Added a direct module entry point for the GUI

The branch adds pyemsi/gui/__main__.py so the GUI can be launched with python -m pyemsi.gui.

It also adds support for an optional workspace path argument so a folder can be opened directly at startup. This makes the packaged launcher flow align with the normal module-based entry path.

### 5. Added an NSIS installer

A new installer script was added at installer/pyemsi.nsi.

The NSIS installer packages the already-built portable runtime into a user-level Windows installer with:

- installation under %LOCALAPPDATA%\pyemsi
- no elevation requirement (RequestExecutionLevel user)
- Add/Remove Programs registration under HKCU
- generated uninstaller support
- optional desktop shortcut
- optional Start Menu shortcut group
- Windows Explorer folder and folder-background context menu integration via Open with pyemsi
- finish-page launch action and documentation link

The installer consumes the portable build output from dist/pyemsi rather than rebuilding the application itself.

### 6. Updated packaging/build documentation

The branch updates the repository packaging documentation so the supported distribution outputs are now:

- Python wheel build via the standard Python build flow
- Windows portable GUI runtime via the in-repo packager
- Windows NSIS installer built from the portable runtime

### 7. Added test coverage for the new builder helpers

The branch adds tests/test_build_windows_private_runtime.py to cover key builder behavior, including:

- dependency deduplication and ordering
- parsing of runtime-specific packaging config from pyproject.toml
- ._pth rendering for embedded Python
- launcher command rendering
- output layout construction

## Packaging Flow After This Branch

### Portable build

1. Build the in-place Cython extension.
2. Ensure the Qt resources module is generated.
3. Run tools/build_windows_private_runtime.py.
4. The builder downloads the CPython 3.11 embeddable runtime if it is not already cached.
5. The builder stages the runtime and application into dist/pyemsi.
6. The builder installs dependencies and writes native launchers or fallback batch launchers.
7. The builder can run a smoke test against the staged runtime.

### Installer build

1. Produce the portable runtime under dist/pyemsi.
2. Run makensis installer\pyemsi.nsi.
3. Generate dist/pyemsi-<version>-setup.exe.

## Validation

The following targeted validation was run for this branch:

- python -m pytest tests/test_build_windows_private_runtime.py -q
- Result: 7 tests passed

In addition, the builder itself contains a smoke-test step that validates the staged runtime can import:

- pyemsi
- PySide6
- scienceplots

and that runtime-installed command-line tools such as basedpyright-langserver and pylsp are discoverable from the packaged environment.

## Files Of Interest

- pyproject.toml
- tools/build_windows_private_runtime.py
- tools/launcher.c
- installer/pyemsi.nsi
- pyemsi/gui/__main__.py
- tests/test_build_windows_private_runtime.py
- BUILDING.md
- PACKAGING.md

## Notes

- This packaging flow is Windows-specific because it uses the official CPython embeddable distribution.
- The portable builder expects the compiled extension and generated Qt resources to exist before packaging.
- Native launcher generation is best-effort and gracefully falls back to batch launchers when MSVC is unavailable.
- The installer is intentionally layered on top of the portable runtime output, keeping build responsibilities separated between runtime assembly and installation packaging.
