### PR TITLE
Improve startup time with lazy visualization imports and splash screen

### DIFF
--- a/pyemsi/__init__.py
+++ b/pyemsi/__init__.py
@@ -10,10 +10,10 @@ Main functionality:
 import logging
 from typing import Optional
 
-from .tools.FemapConverter import FemapConverter
-from .plotter import Plotter
 from . import examples
 from .io import EMSolutionOutput
+from .plotter import Plotter
+from .tools.FemapConverter import FemapConverter
 
 __version__ = "0.2.0"
 

--- a/pyemsi/gui/__init__.py
+++ b/pyemsi/gui/__init__.py
@@ -36,6 +36,56 @@ _window: PyEmsiMainWindow | None = None
 _app = None
 
 
+def _create_splash(app):
+    """
+    Create and show a splash screen using the on-disk Icon.svg.
+
+    The SVG is loaded directly from disk rather than via the compiled Qt
+    resource file, because ``pyemsi.resources.resources`` is imported by
+    ``main_window`` and must not be pulled in before the splash is visible.
+
+    Parameters
+    ----------
+    app : QApplication
+        The active QApplication instance (needed for processEvents).
+
+    Returns
+    -------
+    QSplashScreen or None
+        The visible splash widget, or *None* if creation fails for any reason
+        (e.g. missing QtSvg module or icon file not found).
+    """
+    try:
+        import os
+
+        from PySide6.QtCore import QSize, Qt
+        from PySide6.QtGui import QPainter, QPixmap
+        from PySide6.QtSvg import QSvgRenderer
+        from PySide6.QtWidgets import QSplashScreen
+
+        icon_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "resources", "icons", "Icon.svg"))
+        renderer = QSvgRenderer(icon_path)
+        if not renderer.isValid():
+            return None
+        size = QSize(300, 300)
+        pixmap = QPixmap(size)
+        pixmap.fill(Qt.GlobalColor.white)
+        painter = QPainter(pixmap)
+        renderer.render(painter)
+        painter.end()
+        splash = QSplashScreen(pixmap)
+        splash.show()
+        app.processEvents()
+        return splash
+    except Exception:
+        return None
+
+
+def _exec_app(app) -> None:
+    """Run the Qt event loop. Extracted so tests can monkeypatch this."""
+    app.exec()
+
+
 def launch(
     title: str = "pyemsi",
     size: tuple[int, int] | None = None,
@@ -59,11 +109,13 @@ def launch(
 
     from PySide6.QtWidgets import QApplication
 
-    from pyemsi.gui.main_window import PyEmsiMainWindow
-
     _app = QApplication.instance()
     if _app is None:
         _app = QApplication([])
+
+    splash = _create_splash(_app)
+
+    from pyemsi.gui.main_window import PyEmsiMainWindow
 
     _window = PyEmsiMainWindow()
     _window.setWindowTitle(title)
@@ -92,7 +144,11 @@ def launch(
     else:
         _window.resize(*size)
         _window.show()
-    _app.exec()
+
+    if splash is not None:
+        splash.finish(_window)
+
+    _exec_app(_app)
 
 
 def __getattr__(name: str):

--- a/pyemsi/gui/emsolution_output_plot_builder_dialog.py
+++ b/pyemsi/gui/emsolution_output_plot_builder_dialog.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import shutil
 from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-import shutil
 from typing import Any
 
+import scienceplots  # noqa: F401
 from matplotlib import style as mpl_style
+from matplotlib.figure import Figure
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor, QIcon
 from PySide6.QtWidgets import (
@@ -32,10 +34,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from matplotlib.figure import Figure
-
 import pyemsi.resources.resources  # noqa: F401
-import scienceplots  # noqa: F401
 from pyemsi.gui._viewers._matplotlib import MatplotlibViewer
 from pyemsi.io import EMSolutionOutput, PlotAxisOption, PlotSeriesDescriptor
 from pyemsi.settings.manager import SettingsManager

--- a/pyemsi/gui/external_terminal_dock.py
+++ b/pyemsi/gui/external_terminal_dock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
     QDockWidget,
     QLabel,
@@ -11,7 +12,6 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from PySide6.QtGui import QIcon
 
 from pyemsi.widgets.xterm import XtermWidget
 

--- a/pyemsi/gui/field_plot_builder_dialog.py
+++ b/pyemsi/gui/field_plot_builder_dialog.py
@@ -6,7 +6,6 @@ import math
 import os
 
 import numpy as np
-import pyvista as pv
 from PySide6.QtCore import QLocale, Qt, Signal
 from PySide6.QtGui import QColor, QDoubleValidator, QIcon, QPixmap
 from PySide6.QtWidgets import (
@@ -665,6 +664,8 @@ class FieldPlotBuilderDialog(QDialog):
         return 0.0
 
     def _read_plotter_mesh_snapshot(self, plotter: Plotter):
+        import pyvista as pv
+
         reader = getattr(plotter, "reader", None)
         if reader is None:
             return plotter.mesh

--- a/pyemsi/gui/file_viewers.py
+++ b/pyemsi/gui/file_viewers.py
@@ -18,13 +18,13 @@ from ._viewers._constants import (
 )
 from ._viewers._emsolution_input_viewer import EMSolutionInputViewer
 from ._viewers._emsolution_output_viewer import EMSolutionOutputViewer
-from ._viewers._field_viewer import FieldViewer
 from ._viewers._factory import create_viewer
+from ._viewers._field_viewer import FieldViewer
 from ._viewers._image import ImageViewer
 from ._viewers._markdown import MarkdownPreviewViewer, MarkdownViewer
+from ._viewers._matplotlib import MatplotlibViewer
 from ._viewers._python import PythonViewer
 from ._viewers._unsupported import UnsupportedViewer
-from ._viewers._matplotlib import MatplotlibViewer
 
 try:
     _HAS_MATPLOTLIB = True

--- a/pyemsi/gui/ipython_terminal_widget.py
+++ b/pyemsi/gui/ipython_terminal_widget.py
@@ -7,10 +7,11 @@ allowing live interaction with the running application.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-from qtconsole.rich_jupyter_widget import RichJupyterWidget
-from qtconsole.inprocess import QtInProcessKernelManager
+if TYPE_CHECKING:
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget
+    from qtconsole.inprocess import QtInProcessKernelManager
 
 
 def create_ipython_terminal(
@@ -29,6 +30,9 @@ def create_ipython_terminal(
     tuple[RichJupyterWidget, QtInProcessKernelManager]
         The terminal widget and the kernel manager (for later shutdown).
     """
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget
+    from qtconsole.inprocess import QtInProcessKernelManager
+
     kernel_manager = QtInProcessKernelManager()
     kernel_manager.start_kernel()
 

--- a/pyemsi/gui/main_window.py
+++ b/pyemsi/gui/main_window.py
@@ -17,15 +17,15 @@ from PySide6.QtWidgets import QDockWidget, QFileDialog, QMainWindow, QMenu, QMes
 
 import pyemsi.resources.resources  # noqa: F401
 from pyemsi.gui.emsolution_output_plot_builder_dialog import EMSolutionOutputPlotBuilderDialog
-from pyemsi.gui.field_plot_builder_dialog import FieldPlotBuilderDialog
-from pyemsi.widgets.explorer_widget import ExplorerWidget
-from pyemsi.widgets.split_container import SplitContainer
 from pyemsi.gui.external_terminal_dock import ExternalTerminalDock
 from pyemsi.gui.femap_converter_dialog import (
     FemapConverterDialog,
     FemapConverterDialogConfig,
 )
+from pyemsi.gui.field_plot_builder_dialog import FieldPlotBuilderDialog
 from pyemsi.settings import SettingsManager
+from pyemsi.widgets.explorer_widget import ExplorerWidget
+from pyemsi.widgets.split_container import SplitContainer
 
 
 class PyEmsiMainWindow(QMainWindow):
@@ -574,7 +574,7 @@ class PyEmsiMainWindow(QMainWindow):
         """Open *path* in a viewer tab, or focus the existing tab if already open."""
         viewer = self._container.open_file(path)
 
-        from pyemsi.gui.file_viewers import PythonViewer, EMSolutionInputViewer
+        from pyemsi.gui.file_viewers import EMSolutionInputViewer, PythonViewer
 
         if isinstance(viewer, PythonViewer):
             # Connect only once – guard via a dynamic attribute.

--- a/pyemsi/plotter/block_visibility_dialog.py
+++ b/pyemsi/plotter/block_visibility_dialog.py
@@ -1,11 +1,12 @@
 """Block visibility dialog for controlling individual block visibility in multi-block meshes."""
 
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyvistaqt import QtInteractor
+    import pyvista as pv
 
-import pyvista as pv
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
 

--- a/pyemsi/plotter/cell_query_dialog.py
+++ b/pyemsi/plotter/cell_query_dialog.py
@@ -35,7 +35,6 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
-import pyvista as pv
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar

--- a/pyemsi/plotter/color_utils.py
+++ b/pyemsi/plotter/color_utils.py
@@ -110,14 +110,11 @@ def parse_color(color: ColorType) -> Tuple[float, float, float, float]:
     Raises:
         ValueError: If color format is not recognized
     """
-    # Handle PyVista Color objects
-    try:
-        import pyvista as pv
+    import pyvista as pv
 
-        if isinstance(color, pv.Color):
-            return color_from_pyvista(color)
-    except ImportError:
-        pass
+    # Handle PyVista Color objects
+    if isinstance(color, pv.Color):
+        return color_from_pyvista(color)
 
     # Handle string (hex or named color)
     if isinstance(color, str):
@@ -226,31 +223,19 @@ def convert_color(
         return (r, g, b, a)
 
     elif output_format == "pyvista":
-        try:
-            import pyvista as pv
+        import pyvista as pv
 
-            return pv.Color((r, g, b), opacity=a)
-        except ImportError:
-            raise ImportError("PyVista is required for 'pyvista' output format")
+        return pv.Color((r, g, b), opacity=a)
 
     elif output_format == "matplotlib":
         # Matplotlib uses normalized RGBA
         return (r, g, b, a)
 
     elif output_format == "qcolor":
-        try:
-            from PySide6.QtGui import QColor
+        from PySide6.QtGui import QColor
 
-            rgb_255 = denormalize_rgb((r, g, b))
-            return QColor(rgb_255[0], rgb_255[1], rgb_255[2], int(round(a * 255)))
-        except ImportError:
-            try:
-                from PyQt6.QtGui import QColor
-
-                rgb_255 = denormalize_rgb((r, g, b))
-                return QColor(rgb_255[0], rgb_255[1], rgb_255[2], int(round(a * 255)))
-            except ImportError:
-                raise ImportError("PySide6 or PyQt6 is required for 'qcolor' output format")
+        rgb_255 = denormalize_rgb((r, g, b))
+        return QColor(rgb_255[0], rgb_255[1], rgb_255[2], int(round(a * 255)))
 
     else:
         raise ValueError(f"Unsupported output format: {output_format}")
@@ -265,18 +250,15 @@ def color_from_pyvista(pv_color) -> Tuple[float, float, float, float]:
     Returns:
         Normalized RGBA tuple
     """
-    try:
-        import pyvista as pv
+    import pyvista as pv
 
-        if not isinstance(pv_color, pv.Color):
-            raise ValueError("Input must be a pyvista.Color object")
+    if not isinstance(pv_color, pv.Color):
+        raise ValueError("Input must be a pyvista.Color object")
 
-        # PyVista Color has float_rgb property and opacity
-        rgb = pv_color.float_rgb
-        opacity = pv_color.opacity if hasattr(pv_color, "opacity") else 1.0
-        return (*rgb, opacity)
-    except ImportError:
-        raise ImportError("PyVista is required to parse PyVista Color objects")
+    # PyVista Color has float_rgb property and opacity
+    rgb = pv_color.float_rgb
+    opacity = pv_color.opacity if hasattr(pv_color, "opacity") else 1.0
+    return (*rgb, opacity)
 
 
 def color_from_qcolor(qcolor) -> Tuple[float, float, float, float]:
@@ -288,17 +270,9 @@ def color_from_qcolor(qcolor) -> Tuple[float, float, float, float]:
     Returns:
         Normalized RGBA tuple
     """
-    try:
-        from PySide6.QtGui import QColor
+    from PySide6.QtGui import QColor
 
-        qcolor_class = QColor
-    except ImportError:
-        try:
-            from PyQt6.QtGui import QColor
-
-            qcolor_class = QColor
-        except ImportError:
-            raise ImportError("PySide6 or PyQt6 is required to parse QColor objects")
+    qcolor_class = QColor
 
     if not isinstance(qcolor, qcolor_class):
         raise ValueError("Input must be a QColor object")

--- a/pyemsi/plotter/display_settings_dialog.py
+++ b/pyemsi/plotter/display_settings_dialog.py
@@ -1,11 +1,12 @@
 """Display settings dialog for PyVista plotter configuration."""
 
+from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyvistaqt import QtInteractor
+    import pyvista as pv
 
-import pyvista as pv
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
 
@@ -13,16 +14,25 @@ from .colormaps import CMAP_CHOICES, cmap_name_to_choice
 from .color_utils import to_hex
 from pyemsi.widgets.property_tree_widget import PropertyTreeWidget
 
-GRID_VISIBILITY_DICT = {
-    pv.CubeAxesActor.VTK_GRID_LINES_CLOSEST: "all",
-    pv.CubeAxesActor.VTK_GRID_LINES_FURTHEST: "back",
-    pv.CubeAxesActor.VTK_GRID_LINES_ALL: "front",
-}
-TICK_LOCATION_DICT = {
-    pv.CubeAxesActor.VTK_TICKS_INSIDE: "inside",
-    pv.CubeAxesActor.VTK_TICKS_OUTSIDE: "outside",
-    pv.CubeAxesActor.VTK_TICKS_BOTH: "both",
-}
+
+def _grid_visibility_dict() -> dict[int, str]:
+    import pyvista as pv
+
+    return {
+        pv.CubeAxesActor.VTK_GRID_LINES_CLOSEST: "all",
+        pv.CubeAxesActor.VTK_GRID_LINES_FURTHEST: "back",
+        pv.CubeAxesActor.VTK_GRID_LINES_ALL: "front",
+    }
+
+
+def _tick_location_dict() -> dict[int, str]:
+    import pyvista as pv
+
+    return {
+        pv.CubeAxesActor.VTK_TICKS_INSIDE: "inside",
+        pv.CubeAxesActor.VTK_TICKS_OUTSIDE: "outside",
+        pv.CubeAxesActor.VTK_TICKS_BOTH: "both",
+    }
 
 
 class DisplaySettingsDialog(QDialog):
@@ -116,6 +126,8 @@ class DisplaySettingsDialog(QDialog):
         }
 
     def initialize_actors_settings(self):
+        import pyvista as pv
+
         real_actors = [
             actor
             for actor in self.plotter.renderer.actors.values()
@@ -179,6 +191,8 @@ class DisplaySettingsDialog(QDialog):
                 self.initial_actors_settings["opacity"] = "mixed"
 
     def initialize_axes_settings(self):
+        import pyvista as pv
+
         if self.plotter_window._axes_action.isChecked():
             self.initial_axes_settings = {
                 "enabled": True,
@@ -209,6 +223,9 @@ class DisplaySettingsDialog(QDialog):
             }
 
     def initialize_grid_settings(self):
+        grid_visibility_dict = _grid_visibility_dict()
+        tick_location_dict = _tick_location_dict()
+
         if any(x.__class__.__name__ == "CubeAxesActor" for x in self.plotter.renderer.actors.values()):
             self.initial_grid_settings = {
                 "enabled": True,
@@ -224,8 +241,8 @@ class DisplaySettingsDialog(QDialog):
                 "n_xlabels": self.plotter.renderer.cube_axes_actor.n_xlabels,
                 "n_ylabels": self.plotter.renderer.cube_axes_actor.n_ylabels,
                 "n_zlabels": self.plotter.renderer.cube_axes_actor.n_zlabels,
-                "grid": GRID_VISIBILITY_DICT.get(self.plotter.renderer.cube_axes_actor.GetGridLineLocation()),
-                "ticks": TICK_LOCATION_DICT.get(self.plotter.renderer.cube_axes_actor.GetTickLocation()),
+                "grid": grid_visibility_dict.get(self.plotter.renderer.cube_axes_actor.GetGridLineLocation()),
+                "ticks": tick_location_dict.get(self.plotter.renderer.cube_axes_actor.GetTickLocation()),
                 "minor_ticks": self.plotter.renderer.cube_axes_actor.x_axis_minor_tick_visibility,
             }
         else:
@@ -249,6 +266,8 @@ class DisplaySettingsDialog(QDialog):
             }
 
     def initialize_axes_at_origin_settings(self):
+        import pyvista as pv
+
         if self.plotter_window._axes_at_origin_action.isChecked():
             actor = self.plotter_window.get_actor_by_name("AxesAtOriginActor")
             self.initial_axes_at_origin_settings = {
@@ -566,6 +585,9 @@ class DisplaySettingsDialog(QDialog):
         Creates a checkable group with properties for axis visibility, labels, titles,
         grid lines, tick locations, and other grid display options.
         """
+        grid_visibility_choices = list(_grid_visibility_dict().values())
+        tick_location_choices = list(_tick_location_dict().values())
+
         group = self.tree.add_checkable_group(
             name="Grid",
             checked=self.initial_grid_settings["enabled"],
@@ -654,14 +676,14 @@ class DisplaySettingsDialog(QDialog):
             value=self.initial_grid_settings["grid"],
             editor_type="enum",
             parent=group,
-            choices=list(GRID_VISIBILITY_DICT.values()),
+            choices=grid_visibility_choices,
         )
         self.tree.add_property(
             name="Tick Location",
             value=self.initial_grid_settings["ticks"],
             editor_type="enum",
             parent=group,
-            choices=list(TICK_LOCATION_DICT.values()),
+            choices=tick_location_choices,
         )
         self.tree.add_property(
             name="Minor Ticks",
@@ -755,6 +777,7 @@ class DisplaySettingsDialog(QDialog):
         -----
         This method is called by both Ok and Apply buttons.
         """
+        import pyvista as pv
 
         # Apply plotter settings
         self.plotter.renderer.background_color = pv.Color(plotter_settings["background_color"]).float_rgb

--- a/pyemsi/plotter/pick_result_history_dialog.py
+++ b/pyemsi/plotter/pick_result_history_dialog.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QPlainTextEdit
-    from PySide6.QtGui import QFont, QCloseEvent
+    from PySide6.QtGui import QCloseEvent, QFont
+    from PySide6.QtWidgets import QDialog, QHBoxLayout, QPlainTextEdit, QPushButton, QVBoxLayout
+
     from pyemsi.plotter.qt_window import QtPlotterWindow
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QPlainTextEdit
 from PySide6.QtGui import QFont
+from PySide6.QtWidgets import QDialog, QHBoxLayout, QPlainTextEdit, QPushButton, QVBoxLayout
 
 
 class PickResultHistoryDialog(QDialog):

--- a/pyemsi/plotter/plotter.py
+++ b/pyemsi/plotter/plotter.py
@@ -7,27 +7,19 @@ with Qt interactivity using pyvistaqt.QtInteractor and PySide6 backend.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from collections.abc import Sequence
-
-import pyvista as pv
 import numpy as np
 
-# TYPE_CHECKING imports (for type checkers only, not runtime)
 if TYPE_CHECKING:
+    import pyvista as pv
     from pyvistaqt import QtInteractor
+
     from pyemsi.plotter.qt_window import QtPlotterWindow
 
-# Qt imports are optional (only needed for desktop mode)
-try:
-    from pyvistaqt import QtInteractor
-    from pyemsi.plotter.qt_window import QtPlotterWindow
-
-    HAS_QT = True
-except ImportError:
-    HAS_QT = False
+from pyemsi.plotter.qt_window import QtPlotterWindow
 
 
 class Plotter:
@@ -142,9 +134,6 @@ class Plotter:
         **kwargs,
     ) -> None:
         """Initialize Qt-based desktop mode."""
-        if not HAS_QT:
-            raise ImportError("Qt dependencies not available. Install with: pip install PySide6 pyvistaqt")
-
         # Create QtPlotterWindow with stored properties
         self._window = QtPlotterWindow(
             title=self._qt_props.get("title", "pyemsi Plotter"),
@@ -159,6 +148,8 @@ class Plotter:
 
     def _init_notebook_mode(self, **kwargs) -> None:
         """Initialize PyVista native notebook mode."""
+        import pyvista as pv
+
         pv.set_jupyter_backend(self._backend)
         self.plotter = pv.Plotter(**kwargs)
         self._window = None
@@ -202,6 +193,8 @@ class Plotter:
         ValueError
             If the file format is not supported or the file cannot be read.
         """
+        import pyvista as pv
+
         filepath = Path(filepath)
 
         if not filepath.exists():
@@ -216,6 +209,8 @@ class Plotter:
 
     def _time_reader(self):
         """Return the underlying TimeReader when available, else None."""
+        import pyvista as pv
+
         time_reader_type = getattr(pv, "TimeReader", None)
         if time_reader_type is None:
             return None
@@ -271,6 +266,8 @@ class Plotter:
     @property
     def mesh(self) -> pv.DataSet | pv.MultiBlock | None:
         """Get the current mesh."""
+        import pyvista as pv
+
         if self._mesh is None:
             if self.reader is None:
                 raise ValueError("No reader available. Call set_file() first.")
@@ -292,6 +289,8 @@ class Plotter:
 
     def _iter_blocks(self, skip_empty: bool = True):
         """Yield (index, block, name) for single or MultiBlock meshes."""
+        import pyvista as pv
+
         if isinstance(self.mesh, pv.MultiBlock):
             for idx, block in enumerate(self.mesh):
                 if block is None:
@@ -482,6 +481,8 @@ class Plotter:
         list[str]
             List of block name strings.
         """
+        import pyvista as pv
+
         block_names = []
         if isinstance(self.mesh, pv.MultiBlock):
             for idx, block, name in self._iter_blocks(skip_empty=False):
@@ -919,6 +920,8 @@ class Plotter:
         Creates oriented glyphs (arrows, cones, or spheres) at each point/cell
         in the mesh, with optional scaling and density control.
         """
+        import pyvista as pv
+
         if self._vector_props is None:
             return  # No vector properties set
 
@@ -1154,6 +1157,8 @@ class Plotter:
         For MultiBlock meshes, finds the block matching the given name.
         For single meshes, returns the mesh if block_name is None.
         """
+        import pyvista as pv
+
         if self.reader is None:
             raise ValueError("No reader available. Call set_file() first.")
 
@@ -1651,6 +1656,8 @@ class Plotter:
             - results: list of dicts (one per probe point) with sampled data
             - last_sampled: the last sampled PolyData (for advanced users)
         """
+        import pyvista as pv
+
         # Sample from entire mesh
         target = self.mesh
 
@@ -1938,6 +1945,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_point.md
         """
+        import pyvista as pv
+
         if len(point) != 3:
             raise ValueError(f"point must have 3 components, got {len(point)}.")
 
@@ -1997,6 +2006,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_points.md
         """
+        import pyvista as pv
+
         # Validate all points have 3 components
         for i, point in enumerate(points):
             if len(point) != 3:
@@ -2061,6 +2072,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_line.md
         """
+        import pyvista as pv
+
         if resolution < 1:
             raise ValueError(f"resolution must be >= 1, got {resolution}.")
 
@@ -2127,6 +2140,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_lines.md
         """
+        import pyvista as pv
+
         # Normalize resolution to list
         if isinstance(resolution, int):
             resolution_list = [resolution] * len(lines)
@@ -2214,6 +2229,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_arc.md
         """
+        import pyvista as pv
+
         if resolution < 1:
             raise ValueError(f"resolution must be >= 1, got {resolution}.")
 
@@ -2285,6 +2302,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_arcs.md
         """
+        import pyvista as pv
+
         # Normalize resolution to list
         if isinstance(resolution, int):
             resolution_list = [resolution] * len(arcs)
@@ -2382,6 +2401,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_arc_from_normal.md
         """
+        import pyvista as pv
+
         if resolution < 1:
             raise ValueError(f"resolution must be >= 1, got {resolution}.")
 
@@ -2447,6 +2468,8 @@ class Plotter:
 
         See full documentation at docs/api/Plotter/sample_arcs_from_normal.md
         """
+        import pyvista as pv
+
         # Normalize resolution to list
         if isinstance(resolution, int):
             resolution_list = [resolution] * len(arcs)

--- a/pyemsi/plotter/point_query_dialog.py
+++ b/pyemsi/plotter/point_query_dialog.py
@@ -10,36 +10,46 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from PySide6.QtWidgets import QDialog, QSplitter, QTableWidget, QTabWidget, QVBoxLayout, QHBoxLayout
-    from PySide6.QtWidgets import QPushButton, QLabel, QWidget, QMessageBox
-    from pyvistaqt import QtInteractor
-    from pyemsi.plotter.qt_window import QtPlotterWindow
     import pyvista as pv
+    from PySide6.QtWidgets import (
+        QDialog,
+        QHBoxLayout,
+        QLabel,
+        QMessageBox,
+        QPushButton,
+        QSplitter,
+        QTableWidget,
+        QTabWidget,
+        QVBoxLayout,
+        QWidget,
+    )
+    from pyvistaqt import QtInteractor
 
-from PySide6.QtWidgets import (
-    QDialog,
-    QSplitter,
-    QTableWidget,
-    QTabWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QPushButton,
-    QLabel,
-    QWidget,
-    QMessageBox,
-    QTableWidgetItem,
-    QHeaderView,
-    QAbstractItemView,
-    QProgressDialog,
-    QApplication,
-)
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QIcon
-import pyvista as pv
+    from pyemsi.plotter.qt_window import QtPlotterWindow
+
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QProgressDialog,
+    QPushButton,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
 
 
 class PointQueryDialog(QDialog):

--- a/pyemsi/plotter/qt_window.py
+++ b/pyemsi/plotter/qt_window.py
@@ -5,30 +5,34 @@ Provides QtPlotterWindow class that encapsulates Qt application and window
 management for interactive 3D visualization using pyvistaqt.QtInteractor.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
+    import pyvista as pv
     from PySide6.QtWidgets import QApplication, QFrame, QMainWindow, QVBoxLayout
     from pyvistaqt import QtInteractor
+    from vtkmodules.vtkRenderingCore import vtkCellPicker
+
     from pyemsi.plotter.plotter import Plotter
 
-from PySide6.QtWidgets import QApplication, QFrame, QMainWindow, QVBoxLayout, QToolBar, QComboBox, QMessageBox
-from PySide6.QtGui import QAction, QActionGroup, QIcon, QImage, QPixmap
-from PySide6.QtCore import QSize, Qt, QTimer
-from pyvistaqt import QtInteractor
-import pyvista as pv
 import numpy as np
-from vtkmodules.vtkRenderingCore import vtkCellPicker
+from PySide6.QtCore import QSize, Qt, QTimer
+from PySide6.QtGui import QAction, QActionGroup, QIcon, QImage, QPixmap
+from PySide6.QtWidgets import QApplication, QComboBox, QFrame, QMainWindow, QMessageBox, QToolBar, QVBoxLayout
+
 import pyemsi.resources.resources  # noqa: F401
-from .display_settings_dialog import DisplaySettingsDialog
+
 from .block_visibility_dialog import BlockVisibilityDialog
+from .cell_query_dialog import CellQueryDialog
+from .display_settings_dialog import DisplaySettingsDialog
+from .pick_result_history_dialog import PickResultHistoryDialog
+from .point_query_dialog import PointQueryDialog
+from .sample_arcs_dialog import SampleArcsDialog
+from .sample_lines_dialog import SampleLinesDialog
 from .scalar_bar_range_dialog import ScalarBarRangeDialog
 from .scalar_bar_settings_dialog import ScalarBarSettingsDialog
-from .cell_query_dialog import CellQueryDialog
-from .point_query_dialog import PointQueryDialog
-from .pick_result_history_dialog import PickResultHistoryDialog
-from .sample_lines_dialog import SampleLinesDialog
-from .sample_arcs_dialog import SampleArcsDialog
 
 
 class QtPlotterWindow:
@@ -118,6 +122,8 @@ class QtPlotterWindow:
         **qt_interactor_kwargs
             Additional keyword arguments passed to QtInteractor (e.g., off_screen).
         """
+        from pyvistaqt import QtInteractor
+
         # Store reference to parent plotter
         self.parent_plotter = parent_plotter
 
@@ -417,6 +423,8 @@ class QtPlotterWindow:
         Adds a movable toolbar with checkable toggle buttons for axes, bounding box,
         grid display, and a settings button for future configuration dialog.
         """
+        import pyvista as pv
+
         self._display_toolbar = QToolBar("Display Controls")
         self._display_toolbar.setMovable(True)
         self._display_toolbar.setIconSize(QSize(24, 24))
@@ -631,6 +639,8 @@ class QtPlotterWindow:
 
     def _open_block_visibility_dialog(self) -> None:
         """Open block visibility dialog (non-blocking)."""
+        import pyvista as pv
+
         # Only open if parent plotter has multi-block mesh
         if self.parent_plotter is None or not isinstance(self.parent_plotter.mesh, pv.MultiBlock):
             return
@@ -882,6 +892,9 @@ class QtPlotterWindow:
         On a valid left click, the point payload is returned through ``on_picked``.
         The mode remains active until explicitly disabled.
         """
+        import pyvista as pv
+        from vtkmodules.vtkRenderingCore import vtkCellPicker
+
         if not callable(on_picked):
             raise TypeError("on_picked must be callable.")
 
@@ -1081,6 +1094,9 @@ class QtPlotterWindow:
         RuntimeError
             If plotter interactor is not available.
         """
+        import pyvista as pv
+        from vtkmodules.vtkRenderingCore import vtkCellPicker
+
         if not callable(on_picked):
             raise TypeError("on_picked must be callable.")
 

--- a/pyemsi/plotter/sample_arcs_dialog.py
+++ b/pyemsi/plotter/sample_arcs_dialog.py
@@ -10,38 +10,37 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pyvistaqt import QtInteractor
-    from pyemsi.plotter.qt_window import QtPlotterWindow
     import pyvista as pv
+    from pyvistaqt import QtInteractor
 
+    from pyemsi.plotter.qt_window import QtPlotterWindow
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.figure import Figure
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
     QHBoxLayout,
     QHeaderView,
     QLabel,
+    QLineEdit,
     QMessageBox,
     QProgressDialog,
     QPushButton,
-    QApplication,
-    QSplitter,
     QSpinBox,
+    QSplitter,
     QTableWidget,
     QTableWidgetItem,
-    QAbstractItemView,
     QTabWidget,
     QVBoxLayout,
     QWidget,
-    QLineEdit,
 )
-from PySide6.QtCore import Qt
-import numpy as np
-import pyvista as pv
-from matplotlib.backends.backend_qtagg import FigureCanvas
-from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
-from matplotlib.figure import Figure
-
 
 # ---------------------------------------------------------------------------
 # Helper: parse a "x, y, z" string into a float tuple
@@ -271,6 +270,8 @@ class AddArcDialog(QDialog):
 
     def _on_accept(self) -> None:
         """Validate inputs and accept the dialog."""
+        import pyvista as pv
+
         pointa = _parse_xyz(self._pointa_edit.text())
         if pointa is None:
             QMessageBox.warning(self, "Invalid Input", "Point A must be in 'x, y, z' format.")
@@ -490,6 +491,8 @@ class SampleArcsDialog(QDialog):
         row_number: int | None = None,
     ) -> None:
         """Add a 3D arc actor and label for the given arc entry."""
+        import pyvista as pv
+
         actor_name = f"sample_arc_viz_{arc_idx}"
         label_name = f"sample_arc_label_{arc_idx}"
         try:
@@ -1359,6 +1362,8 @@ class SampleArcsDialog(QDialog):
 
     def _restore_visualizations(self) -> None:
         """Re-draw 3D actors for all current arcs (called after dialog reopen)."""
+        import pyvista as pv
+
         if not self._arcs:
             return
 

--- a/pyemsi/plotter/sample_lines_dialog.py
+++ b/pyemsi/plotter/sample_lines_dialog.py
@@ -10,38 +10,37 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pyvistaqt import QtInteractor
-    from pyemsi.plotter.qt_window import QtPlotterWindow
     import pyvista as pv
+    from pyvistaqt import QtInteractor
 
+    from pyemsi.plotter.qt_window import QtPlotterWindow
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.figure import Figure
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QApplication,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
     QHBoxLayout,
     QHeaderView,
     QLabel,
+    QLineEdit,
     QMessageBox,
     QProgressDialog,
     QPushButton,
-    QApplication,
-    QSplitter,
     QSpinBox,
+    QSplitter,
     QTableWidget,
     QTableWidgetItem,
-    QAbstractItemView,
     QTabWidget,
     QVBoxLayout,
     QWidget,
-    QLineEdit,
 )
-from PySide6.QtCore import Qt
-import numpy as np
-import pyvista as pv
-from matplotlib.backends.backend_qtagg import FigureCanvas
-from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
-from matplotlib.figure import Figure
-
 
 # ---------------------------------------------------------------------------
 # Helper: parse a "x, y, z" string into a float tuple
@@ -441,6 +440,8 @@ class SampleLinesDialog(QDialog):
         row_number: int | None = None,
     ) -> None:
         """Add a 3D line actor and label for the given line entry."""
+        import pyvista as pv
+
         actor_name = f"sample_line_viz_{line_idx}"
         label_name = f"sample_line_label_{line_idx}"
         try:
@@ -1316,6 +1317,8 @@ class SampleLinesDialog(QDialog):
 
     def _restore_visualizations(self) -> None:
         """Re-draw 3D actors for all current lines (called after dialog reopen)."""
+        import pyvista as pv
+
         if not self._lines:
             return
 

--- a/pyemsi/plotter/scalar_bar_range_dialog.py
+++ b/pyemsi/plotter/scalar_bar_range_dialog.py
@@ -3,9 +3,9 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import pyvista as pv
     from pyvistaqt import QtInteractor
 
-import pyvista as pv
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (

--- a/pyemsi/plotter/scalar_bar_settings_dialog.py
+++ b/pyemsi/plotter/scalar_bar_settings_dialog.py
@@ -3,15 +3,16 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import pyvista as pv
     from pyvistaqt import QtInteractor
     from vtk import vtkScalarBarActor
 
-import pyvista as pv
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
 
-from .color_utils import to_hex
 from pyemsi.widgets.property_tree_widget import PropertyTreeWidget
+
+from .color_utils import to_hex
 
 
 class ScalarBarSettingsDialog(QDialog):
@@ -283,6 +284,8 @@ class ScalarBarSettingsDialog(QDialog):
 
     def _apply_settings(self) -> None:
         """Apply settings from the property tree to the plotter."""
+        import pyvista as pv
+
         # Get all values from tree
         all_values = self.tree.get_all_values()
 
@@ -344,6 +347,8 @@ class ScalarBarSettingsDialog(QDialog):
 
     def _restore_initial_settings(self) -> None:
         """Restore initial settings to scalar bars in the plotter."""
+        import pyvista as pv
+
         scalar_bar: vtkScalarBarActor
         for scalar_bar_key, scalar_bar in self.plotter.scalar_bars.items():
             settings = self.initial_scalar_bars_settings[scalar_bar_key]

--- a/pyemsi/tools/FemapConverter.py
+++ b/pyemsi/tools/FemapConverter.py
@@ -1,52 +1,23 @@
 # TODO: cythonize femapconverter
+from __future__ import annotations
+
 import json
 import logging
 import re
 import shutil
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pyvista as pv
 
 import numpy as np
-import pyvista as pv
-from vtk import (
-    VTK_HEXAHEDRON,
-    VTK_LINE,
-    VTK_QUAD,
-    VTK_QUADRATIC_HEXAHEDRON,
-    VTK_QUADRATIC_QUAD,
-    VTK_QUADRATIC_TETRA,
-    VTK_QUADRATIC_TRIANGLE,
-    VTK_QUADRATIC_WEDGE,
-    VTK_TETRA,
-    VTK_TRIANGLE,
-    VTK_VERTEX,
-    VTK_WEDGE,
-    vtkPoints,
-    vtkUnstructuredGrid,
-    vtkXMLMultiBlockDataWriter,
-)
 
 from pyemsi.core.femap_parser import FEMAPParser
 
 # Module-level logger
 logger = logging.getLogger(__name__)
-
-# FEMAP topology to VTK cell type mapping
-# Format: femap_topology_id -> (vtk_cell_type, num_nodes)
-FEMAP_TO_VTK = {
-    9: (VTK_VERTEX, 1),  # Point -> VTK_VERTEX
-    0: (VTK_LINE, 2),  # Line2 -> VTK_LINE
-    2: (VTK_TRIANGLE, 3),  # Tri3 -> VTK_TRIANGLE
-    3: (VTK_QUADRATIC_TRIANGLE, 6),  # Tri6 -> VTK_QUADRATIC_TRIANGLE
-    4: (VTK_QUAD, 4),  # Quad4 -> VTK_QUAD
-    5: (VTK_QUADRATIC_QUAD, 8),  # Quad8 -> VTK_QUADRATIC_QUAD
-    6: (VTK_TETRA, 4),  # Tetra4 -> VTK_TETRA
-    10: (VTK_QUADRATIC_TETRA, 10),  # Tetra10 -> VTK_QUADRATIC_TETRA
-    7: (VTK_WEDGE, 6),  # Wedge6 -> VTK_WEDGE
-    11: (VTK_QUADRATIC_WEDGE, 15),  # Wedge15 -> VTK_QUADRATIC_WEDGE
-    8: (VTK_HEXAHEDRON, 8),  # Brick8 -> VTK_HEXAHEDRON
-    12: (VTK_QUADRATIC_HEXAHEDRON, 20),  # Brick20 -> VTK_QUADRATIC_HEXAHEDRON
-}
 
 FORCE_2D_TOPOLOGY = {
     8: 4,  # Brick8 -> Quad4
@@ -54,6 +25,38 @@ FORCE_2D_TOPOLOGY = {
     7: 2,  # Wedge6 -> Tri3
     11: 3,  # Wedge15 -> Tri6
 }
+
+
+def _get_femap_to_vtk() -> dict[int, tuple[int, int]]:
+    from vtk import (
+        VTK_HEXAHEDRON,
+        VTK_LINE,
+        VTK_QUAD,
+        VTK_QUADRATIC_HEXAHEDRON,
+        VTK_QUADRATIC_QUAD,
+        VTK_QUADRATIC_TETRA,
+        VTK_QUADRATIC_TRIANGLE,
+        VTK_QUADRATIC_WEDGE,
+        VTK_TETRA,
+        VTK_TRIANGLE,
+        VTK_VERTEX,
+        VTK_WEDGE,
+    )
+
+    return {
+        9: (VTK_VERTEX, 1),  # Point -> VTK_VERTEX
+        0: (VTK_LINE, 2),  # Line2 -> VTK_LINE
+        2: (VTK_TRIANGLE, 3),  # Tri3 -> VTK_TRIANGLE
+        3: (VTK_QUADRATIC_TRIANGLE, 6),  # Tri6 -> VTK_QUADRATIC_TRIANGLE
+        4: (VTK_QUAD, 4),  # Quad4 -> VTK_QUAD
+        5: (VTK_QUADRATIC_QUAD, 8),  # Quad8 -> VTK_QUADRATIC_QUAD
+        6: (VTK_TETRA, 4),  # Tetra4 -> VTK_TETRA
+        10: (VTK_QUADRATIC_TETRA, 10),  # Tetra10 -> VTK_QUADRATIC_TETRA
+        7: (VTK_WEDGE, 6),  # Wedge6 -> VTK_WEDGE
+        11: (VTK_QUADRATIC_WEDGE, 15),  # Wedge15 -> VTK_QUADRATIC_WEDGE
+        8: (VTK_HEXAHEDRON, 8),  # Brick8 -> VTK_HEXAHEDRON
+        12: (VTK_QUADRATIC_HEXAHEDRON, 20),  # Brick20 -> VTK_QUADRATIC_HEXAHEDRON
+    }
 
 
 class FemapConverter:
@@ -229,6 +232,9 @@ class FemapConverter:
         logger.info("Created PVD file: %s with %d time steps", self.pvd_file, len(self.sets))
 
     def _write_vtm_file(self, mesh: pv.MultiBlock | pv.UnstructuredGrid, path: str | Path) -> None:
+        import pyvista as pv
+        from vtk import vtkXMLMultiBlockDataWriter
+
         if isinstance(mesh, pv.UnstructuredGrid):
             mesh = self._vtu_to_vtm(mesh)
         writer = vtkXMLMultiBlockDataWriter()
@@ -242,6 +248,8 @@ class FemapConverter:
     def _vtu_to_vtm(self, unstructured_grid: pv.UnstructuredGrid) -> pv.MultiBlock:
         # Create a new MultiBlock dataset based on the PropertyID cell data
         # Create a MultiBlock dataset and add the subgrid
+        import pyvista as pv
+
         logger.debug("Converting UnstructuredGrid to MultiBlock by PropertyID")
         mb = pv.MultiBlock()
         for prop_id in self.unique_props:
@@ -262,6 +270,11 @@ class FemapConverter:
         return mb
 
     def _build_mesh(self, mesh_file: str | Path, force_2d: bool = False) -> None:
+        import pyvista as pv
+        from vtk import vtkPoints, vtkUnstructuredGrid
+
+        femap_to_vtk = _get_femap_to_vtk()
+
         logger.info("Building mesh from: %s", mesh_file)
         parser = FEMAPParser(str(mesh_file))
         nodes = parser.get_nodes(force_2d)
@@ -294,10 +307,10 @@ class FemapConverter:
                 except KeyError as exc:
                     raise ValueError(f"Cannot force 2D for element topology {topo}") from exc
 
-            if topo not in FEMAP_TO_VTK:
+            if topo not in femap_to_vtk:
                 continue
 
-            vtk_type, num_nodes_required = FEMAP_TO_VTK[topo]
+            vtk_type, num_nodes_required = femap_to_vtk[topo]
             elem_nodes = elem["nodes"][:num_nodes_required]
 
             if len(elem_nodes) < num_nodes_required:

--- a/pyemsi/tools/run_femap_converter.py
+++ b/pyemsi/tools/run_femap_converter.py
@@ -6,6 +6,9 @@ import logging
 import os
 import sys
 
+import pyemsi
+from pyemsi.tools.FemapConverter import FemapConverter
+
 
 def _ensure_repo_root_on_sys_path() -> None:
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
@@ -14,9 +17,6 @@ def _ensure_repo_root_on_sys_path() -> None:
 
 
 _ensure_repo_root_on_sys_path()
-
-import pyemsi
-from pyemsi.tools.FemapConverter import FemapConverter
 
 
 def _load_config(config_path: str) -> dict:

--- a/pyemsi/tools/run_femap_converter.py
+++ b/pyemsi/tools/run_femap_converter.py
@@ -12,12 +12,12 @@ def _ensure_repo_root_on_sys_path() -> None:
 
 _ensure_repo_root_on_sys_path()
 
-import argparse
-import json
-import logging
+import argparse  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
 
-import pyemsi
-from pyemsi.tools.FemapConverter import FemapConverter
+import pyemsi  # noqa: E402
+from pyemsi.tools.FemapConverter import FemapConverter  # noqa: E402
 
 
 def _load_config(config_path: str) -> dict:

--- a/pyemsi/tools/run_femap_converter.py
+++ b/pyemsi/tools/run_femap_converter.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-import argparse
-import json
-import logging
 import os
 import sys
-
-import pyemsi
-from pyemsi.tools.FemapConverter import FemapConverter
 
 
 def _ensure_repo_root_on_sys_path() -> None:
@@ -17,6 +11,13 @@ def _ensure_repo_root_on_sys_path() -> None:
 
 
 _ensure_repo_root_on_sys_path()
+
+import argparse
+import json
+import logging
+
+import pyemsi
+from pyemsi.tools.FemapConverter import FemapConverter
 
 
 def _load_config(config_path: str) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "python-lsp-server[websockets]",
     "basedpyright>=1.31.4",
     "scienceplots",
+    "gmsh",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ qtconsole
 python-lsp-server[websockets]
 basedpyright>=1.31.4
 scienceplots
+gmsh

--- a/tests/test_gui_launch.py
+++ b/tests/test_gui_launch.py
@@ -1,0 +1,170 @@
+"""Tests for gui.launch() – splash screen ordering and robustness."""
+
+from __future__ import annotations
+
+import pyemsi.gui as gui_module
+from pyemsi.gui import main_window as main_window_module
+from PySide6.QtWidgets import QApplication, QSplashScreen, QWidget
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+
+def _ensure_app() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class _FakeSplash:
+    """Records calls to finish() without touching a real QSplashScreen."""
+
+    def __init__(self) -> None:
+        self.finish_calls: list = []
+
+    def finish(self, widget) -> None:
+        self.finish_calls.append(widget)
+
+
+class _FakeWindow(QWidget):
+    """Minimal stand-in for PyEmsiMainWindow – no heavy Qt subsystems."""
+
+    def setWindowTitle(self, title: str) -> None:  # noqa: N802
+        pass
+
+    def should_show_maximized_on_launch(self) -> bool:
+        return False
+
+    def push_to_namespace(self, **kwargs) -> None:
+        pass
+
+    @property
+    def container(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_splash_shown_before_window_constructed(monkeypatch):
+    """_create_splash must be called before PyEmsiMainWindow() runs."""
+    _ensure_app()
+    call_log: list[str] = []
+    splash = _FakeSplash()
+
+    def _mock_create_splash(app):
+        call_log.append("splash")
+        return splash
+
+    class _RecordingWindow(_FakeWindow):
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            call_log.append("window")
+
+    monkeypatch.setattr(gui_module, "_create_splash", _mock_create_splash)
+    monkeypatch.setattr(main_window_module, "PyEmsiMainWindow", _RecordingWindow)
+    monkeypatch.setattr(gui_module, "_exec_app", lambda app: None)
+    monkeypatch.setattr(gui_module, "_window", None)
+    monkeypatch.setattr(gui_module, "_app", None)
+
+    gui_module.launch()
+
+    assert "splash" in call_log and "window" in call_log
+    assert call_log.index("splash") < call_log.index("window"), (
+        "Splash must appear before PyEmsiMainWindow is constructed"
+    )
+
+
+def test_splash_finished_after_window_shown(monkeypatch):
+    """splash.finish() must be called after window.show()."""
+    _ensure_app()
+    call_log: list[str] = []
+    splash = _FakeSplash()
+
+    original_finish = splash.finish
+
+    def _recording_finish(widget) -> None:
+        call_log.append("finish")
+        original_finish(widget)
+
+    splash.finish = _recording_finish
+
+    def _mock_create_splash(app):
+        return splash
+
+    class _RecordingWindow(_FakeWindow):
+        def show(self) -> None:
+            call_log.append("show")
+            super().show()
+
+    monkeypatch.setattr(gui_module, "_create_splash", _mock_create_splash)
+    monkeypatch.setattr(main_window_module, "PyEmsiMainWindow", _RecordingWindow)
+    monkeypatch.setattr(gui_module, "_exec_app", lambda app: None)
+    monkeypatch.setattr(gui_module, "_window", None)
+    monkeypatch.setattr(gui_module, "_app", None)
+
+    gui_module.launch()
+
+    assert "show" in call_log and "finish" in call_log
+    assert call_log.index("show") < call_log.index("finish"), "splash.finish() must be called after window.show()"
+
+
+def test_splash_finished_with_window_instance(monkeypatch):
+    """splash.finish() receives the main window as its argument."""
+    _ensure_app()
+    splash = _FakeSplash()
+
+    def _mock_create_splash(app):
+        return splash
+
+    class _TrackedWindow(_FakeWindow):
+        pass
+
+    monkeypatch.setattr(gui_module, "_create_splash", _mock_create_splash)
+    monkeypatch.setattr(main_window_module, "PyEmsiMainWindow", _TrackedWindow)
+    monkeypatch.setattr(gui_module, "_exec_app", lambda app: None)
+    monkeypatch.setattr(gui_module, "_window", None)
+    monkeypatch.setattr(gui_module, "_app", None)
+
+    gui_module.launch()
+
+    assert len(splash.finish_calls) == 1
+    assert isinstance(splash.finish_calls[0], _TrackedWindow)
+
+
+def test_launch_handles_no_splash(monkeypatch):
+    """launch() completes without error when _create_splash returns None."""
+    _ensure_app()
+
+    def _mock_create_splash(app):
+        return None
+
+    class _FakeWindow2(_FakeWindow):
+        pass
+
+    monkeypatch.setattr(gui_module, "_create_splash", _mock_create_splash)
+    monkeypatch.setattr(main_window_module, "PyEmsiMainWindow", _FakeWindow2)
+    monkeypatch.setattr(gui_module, "_exec_app", lambda app: None)
+    monkeypatch.setattr(gui_module, "_window", None)
+    monkeypatch.setattr(gui_module, "_app", None)
+
+    gui_module.launch()  # must not raise
+
+    assert gui_module._window is not None
+
+
+def test_create_splash_returns_splash_screen():
+    """Integration: _create_splash uses the on-disk icon and returns a QSplashScreen."""
+    app = _ensure_app()
+    splash = gui_module._create_splash(app)
+    try:
+        assert splash is not None, "_create_splash returned None – is PySide6.QtSvg installed and Icon.svg present?"
+        assert isinstance(splash, QSplashScreen)
+    finally:
+        if splash is not None:
+            splash.close()


### PR DESCRIPTION
## Summary
- defer importing heavy visualization dependencies such as `pyvista`, `vtk`, and `pyvistaqt` until plotter and converter code paths actually need them
- show a splash screen before constructing `PyEmsiMainWindow` so startup has immediate visual feedback while the GUI finishes loading
- keep the converter runner and related GUI integrations working with the lazy import boundaries

## Details
- moves plotter and converter runtime imports into the methods that use them, reducing work performed during initial `pyemsi` and GUI startup
- updates the Qt plotter window to instantiate `QtInteractor` and VTK picker types lazily instead of at module import time
- adds a splash helper in `pyemsi.gui.launch()` that renders the existing `Icon.svg` from disk before the main window and closes it after the window is shown
- adds focused launch tests covering splash creation order, finish timing, window handoff, and the no-splash fallback path

## Validation
- `pytest tests/test_gui_launch.py`